### PR TITLE
Lazy load hero scene and throttle 3D animation updates

### DIFF
--- a/src/components/HeroCanvas.tsx
+++ b/src/components/HeroCanvas.tsx
@@ -45,7 +45,7 @@ const Particles = ({ visibleRef }: { visibleRef: MutableRefObject<boolean> }) =>
   useFrame(({ clock }) => {
     if (!visibleRef.current || !pointsRef.current) return;
     const elapsed = clock.getElapsedTime();
-    if (elapsed - lastFrame.current < 1 / 45) return;
+    if (elapsed - lastFrame.current < 1 / 60) return;
     lastFrame.current = elapsed;
     pointsRef.current.rotation.y = elapsed * 0.06;
     pointsRef.current.rotation.x = Math.sin(elapsed * 0.3) * 0.08;
@@ -72,7 +72,7 @@ const Ribbon = ({ visibleRef }: { visibleRef: MutableRefObject<boolean> }) => {
   useFrame(({ clock }) => {
     if (!visibleRef.current || !meshRef.current) return;
     const elapsed = clock.getElapsedTime();
-    if (elapsed - lastFrame.current < 1 / 45) return;
+    if (elapsed - lastFrame.current < 1 / 60) return;
     lastFrame.current = elapsed;
 
     meshRef.current.rotation.y = elapsed * 0.18;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,11 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, Code2, Sparkles, PenSquare } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { Suspense, lazy } from 'react';
 import { Button } from '@/components/ui/button';
-import Hero3D from '@/components/Hero3D';
 import cvData from '../../public/data/cv.json';
+
+const Hero3D = lazy(() => import('@/components/Hero3D'));
 
 export default function Home() {
   const prefersReducedMotion = useReducedMotion();
@@ -12,7 +14,13 @@ export default function Home() {
     <div className="min-h-screen">
       {/* Hero Section */}
       <section className="relative min-h-screen flex items-center justify-center overflow-hidden">
-        <Hero3D />
+        <Suspense
+          fallback={
+            <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(124,58,237,0.35),_transparent_60%),radial-gradient(circle_at_bottom,_rgba(14,165,233,0.25),_transparent_55%)]" />
+          }
+        >
+          <Hero3D />
+        </Suspense>
 
         <div className="container mx-auto px-6 relative z-10">
           <motion.div


### PR DESCRIPTION
## Summary
- lazily load the Hero3D component on the home page with a neon gradient fallback to shrink the initial bundle
- cap three.js animation updates at 60 FPS while preserving the existing visibility handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a788a8948322961a0b32b8f0d8b5