### PR TITLE
Add creative series and artworks sections and routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,10 @@ import type { SupportedLanguage } from "./lib/googleTranslate";
 
 const Home = lazy(() => import("./pages/Home"));
 const Portfolio = lazy(() => import("./pages/Portfolio"));
+const Series = lazy(() => import("./pages/Series"));
+const SeriesDetail = lazy(() => import("./pages/SeriesDetail"));
+const Artworks = lazy(() => import("./pages/Artworks"));
+const ArtDetail = lazy(() => import("./pages/ArtDetail"));
 const About = lazy(() => import("./pages/About"));
 const Thoughts = lazy(() => import("./pages/Thoughts"));
 const ThoughtDetail = lazy(() => import("./pages/ThoughtDetail"));
@@ -58,6 +62,10 @@ const App = () => {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/portfolio" element={<Portfolio />} />
+              <Route path="/series" element={<Series />} />
+              <Route path="/series/:slug" element={<SeriesDetail />} />
+              <Route path="/art" element={<Artworks />} />
+              <Route path="/art/:slug" element={<ArtDetail />} />
               <Route path="/about" element={<About />} />
               <Route path="/thoughts" element={<Thoughts />} />
               <Route path="/thoughts/:slug" element={<ThoughtDetail />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,6 +14,8 @@ export default function Navbar() {
   const navLinks = [
     { href: '/', label: 'Home' },
     { href: '/portfolio', label: 'Portfolio' },
+    { href: '/series', label: 'Séries' },
+    { href: '/art', label: 'Obras' },
     { href: '/about', label: 'Sobre' },
     { href: '/thoughts', label: 'Pensamentos' },
     { href: '/contact', label: 'Contato' },

--- a/src/pages/ArtDetail.tsx
+++ b/src/pages/ArtDetail.tsx
@@ -1,0 +1,104 @@
+import { Link, useParams } from 'react-router-dom';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, ExternalLink, Layers } from 'lucide-react';
+import cvData from '../../public/data/cv.json';
+import { Button } from '@/components/ui/button';
+
+export default function ArtDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const prefersReducedMotion = useReducedMotion();
+  const artwork = cvData.artworks.find((item) => item.slug === slug);
+
+  if (!artwork) {
+    return (
+      <div className="min-h-screen py-24 px-6">
+        <div className="container mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-display font-bold text-primary">Obra não encontrada</h1>
+          <p className="mt-4 text-muted-foreground">
+            Não conseguimos localizar esta obra digital. Visita a galeria completa para descobrir outras experiências.
+          </p>
+          <Button asChild className="mt-8 rounded-full">
+            <Link to="/art">Ver todas as obras</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen py-24 px-6">
+      <div className="container mx-auto max-w-4xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="rounded-3xl border border-border/60 bg-card/70 p-8 shadow-[0_52px_95px_-75px_rgba(14,165,233,0.85)] backdrop-blur-xl"
+        >
+          <Button
+            asChild
+            variant="ghost"
+            className="mb-6 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+          >
+            <Link to="/art">
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Voltar para a galeria
+            </Link>
+          </Button>
+
+          <header className="flex flex-col gap-4">
+            <h1 className="text-4xl font-display font-semibold text-foreground">{artwork.title}</h1>
+            <div className="flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                {artwork.year}
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                <Layers className="h-3 w-3" aria-hidden />
+                {artwork.materials.join(' • ')}
+              </span>
+            </div>
+            <p className="text-lg text-muted-foreground/90">{artwork.description}</p>
+          </header>
+
+          <div className="mt-10 grid gap-6">
+            {artwork.media.map((mediaSrc, index) => (
+              <figure
+                key={mediaSrc}
+                className="overflow-hidden rounded-3xl border border-border/60 bg-background/40"
+              >
+                <img
+                  src={mediaSrc}
+                  alt={`${artwork.title} – visual ${index + 1}`}
+                  loading="lazy"
+                  decoding="async"
+                  width={960}
+                  height={540}
+                  className="w-full object-cover"
+                />
+              </figure>
+            ))}
+          </div>
+
+          {artwork.url3d && (
+            <div className="mt-10 flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-border/60 bg-background/50 p-6">
+              <div>
+                <h2 className="text-xl font-display font-semibold text-foreground">Exploração 3D</h2>
+                <p className="text-sm text-muted-foreground/80">
+                  Abre a experiência completa em uma nova aba para interagir com o modelo 3D e a ambientação sonora.
+                </p>
+              </div>
+              <a
+                href={artwork.url3d}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-primary via-secondary to-accent px-5 py-2 text-sm font-semibold text-white shadow-[0_18px_45px_-28px_rgba(124,58,237,0.85)] transition hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                Visitar experiência imersiva
+                <ExternalLink className="h-4 w-4" aria-hidden />
+              </a>
+            </div>
+          )}
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Artworks.tsx
+++ b/src/pages/Artworks.tsx
@@ -1,0 +1,96 @@
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, ArrowRight, Palette } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import cvData from '../../public/data/cv.json';
+import { Button } from '@/components/ui/button';
+
+export default function Artworks() {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <div className="min-h-screen py-24 px-6">
+      <div className="container mx-auto max-w-5xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+        >
+          <Button
+            asChild
+            variant="ghost"
+            className="mb-8 rounded-full border border-border/60 bg-card/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+          >
+            <Link to="/portfolio">
+              <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
+              Voltar ao portfolio
+            </Link>
+          </Button>
+
+          <header className="mb-12 text-center">
+            <h1 className="text-5xl md:text-6xl font-display font-bold mb-4">
+              <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
+                Obras digitais
+              </span>
+            </h1>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
+              Explorações visuais, protótipos interativos e experiências 3D criadas para artistas e parceiros.
+            </p>
+          </header>
+
+          <div className="grid gap-8 md:grid-cols-2">
+            {cvData.artworks.map((artwork, index) => (
+              <motion.article
+                key={artwork.slug}
+                initial={prefersReducedMotion ? undefined : { opacity: 0, y: 28 }}
+                animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.1, duration: 0.45 }}
+                className="group flex h-full flex-col overflow-hidden rounded-3xl border border-border/70 bg-card/70 shadow-[0_45px_85px_-70px_rgba(14,165,233,0.75)] backdrop-blur-xl"
+              >
+                <div className="relative aspect-[16/9] w-full overflow-hidden bg-gradient-to-br from-primary/20 via-secondary/20 to-accent/20">
+                  <img
+                    src={artwork.media[0]}
+                    alt={artwork.title}
+                    loading="lazy"
+                    decoding="async"
+                    width={640}
+                    height={360}
+                    className="h-full w-full object-cover"
+                  />
+                  <div className="absolute top-4 right-4">
+                    <span className="rounded-full border border-border/60 bg-background/70 px-3 py-1 text-xs font-medium text-muted-foreground">
+                      {artwork.year}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="flex flex-1 flex-col gap-4 p-6">
+                  <div className="flex items-start justify-between">
+                    <h2 className="text-2xl font-display font-semibold transition-colors group-hover:text-primary">
+                      {artwork.title}
+                    </h2>
+                    <span className="rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground">
+                      <Palette className="mr-1 inline h-3 w-3" aria-hidden />
+                      {artwork.materials[0]}
+                    </span>
+                  </div>
+
+                  <p className="text-sm text-muted-foreground/90">{artwork.description}</p>
+
+                  <div className="mt-auto">
+                    <Link
+                      to={`/art/${artwork.slug}`}
+                      className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary/70 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    >
+                      Explorar obra
+                      <ArrowRight className="h-4 w-4" aria-hidden />
+                    </Link>
+                  </div>
+                </div>
+              </motion.article>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -190,6 +190,62 @@ export default function Home() {
           </motion.div>
         </div>
       </section>
+
+      {/* Creative Series & Artworks */}
+      <section className="pb-24 px-6">
+        <div className="container mx-auto">
+          <motion.div
+            initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+            whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.4 }}
+            transition={{ duration: 0.6 }}
+            className="grid gap-8 lg:grid-cols-2"
+          >
+            <div className="rounded-3xl border border-border/70 bg-gradient-to-br from-primary/25 via-secondary/20 to-accent/20 p-8 shadow-[0_45px_85px_-65px_rgba(124,58,237,0.85)]">
+              <h2 className="text-3xl font-display font-semibold text-foreground">Séries Criativas</h2>
+              <p className="mt-4 text-muted-foreground/90">
+                Narrativas em torno de produtos digitais e arte interativa. Conhece a curadoria das experiências que conectam tecnologia, diversidade e storytelling.
+              </p>
+              <Button
+                asChild
+                className="mt-6 rounded-full bg-gradient-to-r from-primary via-secondary to-accent px-6 py-2 text-sm shadow-[0_20px_45px_-28px_rgba(56,189,248,0.65)]"
+              >
+                <Link to="/series">
+                  Explorar séries
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
+                </Link>
+              </Button>
+            </div>
+
+            <div className="rounded-3xl border border-border/70 bg-card/70 p-8 shadow-[0_45px_85px_-70px_rgba(14,165,233,0.75)] backdrop-blur-xl">
+              <h2 className="text-3xl font-display font-semibold text-foreground">Galeria de Obras</h2>
+              <p className="mt-4 text-muted-foreground/90">
+                Visuals, motion e protótipos 3D que expandem o universo Monynha. Passeia por imagens e links imersivos para sentir as experiências completas.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                {cvData.artworks.slice(0, 3).map((artwork) => (
+                  <span
+                    key={artwork.slug}
+                    className="rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground"
+                  >
+                    {artwork.title}
+                  </span>
+                ))}
+              </div>
+              <Button
+                asChild
+                variant="outline"
+                className="mt-6 rounded-full border-border/70"
+              >
+                <Link to="/art">
+                  Ver galeria completa
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
+                </Link>
+              </Button>
+            </div>
+          </motion.div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -149,6 +149,40 @@ export default function Portfolio() {
             </p>
           </motion.div>
         )}
+
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+          whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.3 }}
+          transition={{ duration: 0.6 }}
+          className="mt-16 grid gap-6 lg:grid-cols-2"
+        >
+          <div className="rounded-3xl border border-border/60 bg-card/60 p-6 shadow-[0_40px_75px_-60px_rgba(124,58,237,0.75)] backdrop-blur-xl">
+            <h2 className="text-2xl font-display font-semibold text-foreground">Coleções imersivas</h2>
+            <p className="mt-3 text-sm text-muted-foreground/90">
+              Aprofunda-te em séries que conectam dados, arte e interatividade com curadoria especial.
+            </p>
+            <Button asChild className="mt-5 rounded-full">
+              <Link to="/series">
+                Ver séries
+                <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
+              </Link>
+            </Button>
+          </div>
+
+          <div className="rounded-3xl border border-border/60 bg-gradient-to-r from-primary/20 via-secondary/20 to-accent/25 p-6 shadow-[0_40px_75px_-55px_rgba(56,189,248,0.75)]">
+            <h2 className="text-2xl font-display font-semibold text-foreground">Galeria de obras</h2>
+            <p className="mt-3 text-sm text-muted-foreground/90">
+              Visualiza renderizações, protótipos e motion design que expandem estes projetos.
+            </p>
+            <Button asChild variant="outline" className="mt-5 rounded-full border-border/70">
+              <Link to="/art">
+                Ir para galeria
+                <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
+              </Link>
+            </Button>
+          </div>
+        </motion.div>
       </div>
     </div>
   );

--- a/src/pages/Series.tsx
+++ b/src/pages/Series.tsx
@@ -1,0 +1,83 @@
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, ArrowRight, Calendar } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import cvData from '../../public/data/cv.json';
+import { Button } from '@/components/ui/button';
+
+export default function Series() {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <div className="min-h-screen py-24 px-6">
+      <div className="container mx-auto max-w-5xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+        >
+          <Button
+            asChild
+            variant="ghost"
+            className="mb-8 rounded-full border border-border/60 bg-card/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+          >
+            <Link to="/portfolio">
+              <ArrowLeft className="mr-2 h-4 w-4" aria-hidden />
+              Voltar ao portfolio
+            </Link>
+          </Button>
+
+          <header className="mb-12 text-center">
+            <h1 className="text-5xl md:text-6xl font-display font-bold mb-4">
+              <span className="bg-gradient-to-r from-primary via-secondary to-accent bg-clip-text text-transparent">
+                Séries criativas
+              </span>
+            </h1>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
+              Coleções que reúnem narrativas, experiências e tecnologias exploradas pelo laboratório Monynha.
+            </p>
+          </header>
+
+          <div className="grid gap-8 md:grid-cols-2">
+            {cvData.series.map((serie, index) => (
+              <motion.article
+                key={serie.slug}
+                initial={prefersReducedMotion ? undefined : { opacity: 0, y: 28 }}
+                animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.1, duration: 0.45 }}
+                className="group flex h-full flex-col rounded-3xl border border-border/70 bg-card/70 p-8 shadow-[0_40px_75px_-60px_rgba(56,189,248,0.75)] backdrop-blur-xl"
+              >
+                <div className="flex items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                    <Calendar className="h-3 w-3" aria-hidden />
+                    {serie.year}
+                  </span>
+                  <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                    {serie.works.length} obras
+                  </span>
+                </div>
+
+                <h2 className="mt-6 text-3xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
+                  {serie.title}
+                </h2>
+
+                <p className="mt-4 text-base text-muted-foreground/90">
+                  {serie.description}
+                </p>
+
+                <div className="mt-auto pt-6">
+                  <Link
+                    to={`/series/${serie.slug}`}
+                    className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary/70 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  >
+                    Ver série completa
+                    <ArrowRight className="h-4 w-4" aria-hidden />
+                  </Link>
+                </div>
+              </motion.article>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SeriesDetail.tsx
+++ b/src/pages/SeriesDetail.tsx
@@ -1,0 +1,103 @@
+import { Link, useParams } from 'react-router-dom';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, Calendar, Layers3 } from 'lucide-react';
+import cvData from '../../public/data/cv.json';
+import { Button } from '@/components/ui/button';
+
+const getWorksFromSeries = (slugs: string[]) =>
+  cvData.artworks.filter((artwork) => slugs.includes(artwork.slug));
+
+export default function SeriesDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const prefersReducedMotion = useReducedMotion();
+  const serie = cvData.series.find((item) => item.slug === slug);
+
+  if (!serie) {
+    return (
+      <div className="min-h-screen py-24 px-6">
+        <div className="container mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-display font-bold text-primary">Série não encontrada</h1>
+          <p className="mt-4 text-muted-foreground">
+            A série procurada não existe ou foi arquivada. Volta para a biblioteca criativa para explorar outras experiências.
+          </p>
+          <Button asChild className="mt-8 rounded-full">
+            <Link to="/series">Ver todas as séries</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const works = getWorksFromSeries(serie.works);
+
+  return (
+    <div className="min-h-screen py-24 px-6">
+      <div className="container mx-auto max-w-4xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="rounded-3xl border border-border/60 bg-card/70 p-8 shadow-[0_48px_85px_-70px_rgba(124,58,237,0.85)] backdrop-blur-xl"
+        >
+          <Button
+            asChild
+            variant="ghost"
+            className="mb-6 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+          >
+            <Link to="/series">
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Voltar para séries
+            </Link>
+          </Button>
+
+          <div className="flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              <Calendar className="h-3 w-3" aria-hidden />
+              {serie.year}
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              <Layers3 className="h-3 w-3" aria-hidden />
+              {works.length} obras destacadas
+            </span>
+          </div>
+
+          <h1 className="mt-6 text-4xl font-display font-semibold text-foreground">{serie.title}</h1>
+
+          <p className="mt-4 text-lg text-muted-foreground/90">{serie.description}</p>
+
+          <div className="mt-10 grid gap-6">
+            {works.map((artwork) => (
+              <Link
+                key={artwork.slug}
+                to={`/art/${artwork.slug}`}
+                className="group flex flex-col gap-4 rounded-2xl border border-border/60 bg-background/40 p-6 transition hover:border-primary/70 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h2 className="text-2xl font-display font-semibold transition-colors group-hover:text-primary">
+                      {artwork.title}
+                    </h2>
+                    <p className="mt-2 text-sm text-muted-foreground/80">{artwork.materials.join(' • ')}</p>
+                  </div>
+                  <span className="self-start rounded-full border border-border/60 bg-card/60 px-3 py-1 text-xs font-medium text-muted-foreground">
+                    {artwork.year}
+                  </span>
+                </div>
+                <p className="text-sm text-foreground/80">{artwork.description}</p>
+                <span className="inline-flex items-center gap-2 text-sm font-semibold text-primary">
+                  Acessar obra
+                  <ArrowLeft className="h-4 w-4 rotate-180" aria-hidden />
+                </span>
+              </Link>
+            ))}
+            {works.length === 0 && (
+              <p className="rounded-2xl border border-dashed border-border/60 bg-background/40 p-6 text-sm text-muted-foreground">
+                Ainda não existem obras associadas a esta série. Volta em breve para novidades luminosas.
+              </p>
+            )}
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add series and artworks listing/detail routes that consume cv.json metadata and integrate with navigation
- enrich home and portfolio pages with calls-to-action pointing to the new creative collections
- keep styling and accessibility in line with existing neon aesthetic while reusing reduced-motion handling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a788a8948322961a0b32b8f0d8b5