### PR TITLE
Add creative series and artwork detail pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ const Portfolio = lazy(() => import("./pages/Portfolio"));
 const About = lazy(() => import("./pages/About"));
 const Thoughts = lazy(() => import("./pages/Thoughts"));
 const ThoughtDetail = lazy(() => import("./pages/ThoughtDetail"));
+const SeriesDetail = lazy(() => import("./pages/SeriesDetail"));
+const ArtworkDetail = lazy(() => import("./pages/ArtworkDetail"));
 const Contact = lazy(() => import("./pages/Contact"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
@@ -61,6 +63,8 @@ const App = () => {
               <Route path="/about" element={<About />} />
               <Route path="/thoughts" element={<Thoughts />} />
               <Route path="/thoughts/:slug" element={<ThoughtDetail />} />
+              <Route path="/series/:slug" element={<SeriesDetail />} />
+              <Route path="/art/:slug" element={<ArtworkDetail />} />
               <Route path="/contact" element={<Contact />} />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/ArtworkPreview3D.tsx
+++ b/src/components/ArtworkPreview3D.tsx
@@ -1,0 +1,85 @@
+import { Suspense, useEffect, useRef, type MutableRefObject } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import { Mesh } from 'three';
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
+
+const useVisibilityController = () => {
+  const visibleRef = useRef(true);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      visibleRef.current = !document.hidden;
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
+
+  return visibleRef;
+};
+
+const Sculpture = ({ paused, visibleRef }: { paused: boolean; visibleRef: MutableRefObject<boolean> }) => {
+  const meshRef = useRef<Mesh>(null);
+  const lastFrame = useRef(0);
+
+  useFrame(({ clock }) => {
+    if (paused || !meshRef.current || !visibleRef.current) return;
+    const elapsed = clock.getElapsedTime();
+    if (elapsed - lastFrame.current < 1 / 45) return;
+    lastFrame.current = elapsed;
+
+    meshRef.current.rotation.y = elapsed * 0.3;
+    meshRef.current.rotation.x = Math.sin(elapsed * 0.4) * 0.35;
+  });
+
+  return (
+    <mesh ref={meshRef} scale={1.4} position={[0, 0, 0]}>
+      <icosahedronGeometry args={[1.1, 2]} />
+      <meshStandardMaterial
+        color="#a855f7"
+        emissive="#0ea5e9"
+        emissiveIntensity={0.45}
+        metalness={0.65}
+        roughness={0.2}
+      />
+    </mesh>
+  );
+};
+
+const Halo = () => (
+  <mesh rotation={[Math.PI / 2, 0, 0]} position={[0, -1.6, 0]}>
+    <torusGeometry args={[1.8, 0.02, 16, 80]} />
+    <meshBasicMaterial color="#22d3ee" transparent opacity={0.4} />
+  </mesh>
+);
+
+export default function ArtworkPreview3D() {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const visibleRef = useVisibilityController();
+
+  return (
+    <div className="relative h-[320px] w-full overflow-hidden rounded-3xl border border-border/60 bg-card/80">
+      <Canvas
+        camera={{ position: [0, 0, 5], fov: 45 }}
+        dpr={[1, 1.5]}
+        gl={{ antialias: true, alpha: true, powerPreference: 'high-performance' }}
+      >
+        <Suspense fallback={null}>
+          <ambientLight intensity={0.7} />
+          <directionalLight position={[4, 6, 5]} intensity={1} color="#c084fc" />
+          <pointLight position={[-4, -4, -4]} intensity={0.7} color="#0ea5e9" />
+          <Sculpture paused={prefersReducedMotion} visibleRef={visibleRef} />
+          <Halo />
+          <OrbitControls
+            enableZoom={false}
+            enablePan={false}
+            enableRotate={!prefersReducedMotion}
+            autoRotate={!prefersReducedMotion}
+            autoRotateSpeed={0.7}
+          />
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+}

--- a/src/pages/ArtworkDetail.tsx
+++ b/src/pages/ArtworkDetail.tsx
@@ -1,0 +1,159 @@
+import { useState, lazy, Suspense } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, ExternalLink, Maximize2 } from 'lucide-react';
+import cvData from '../../public/data/cv.json';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+
+const ArtworkPreview3D = lazy(() => import('@/components/ArtworkPreview3D'));
+
+export default function ArtworkDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const prefersReducedMotion = useReducedMotion();
+  const artwork = cvData.artworks?.find((item) => item.slug === slug);
+  const [lightboxMedia, setLightboxMedia] = useState<string | null>(null);
+  const [show3D, setShow3D] = useState(false);
+
+  if (!artwork) {
+    return (
+      <div className="min-h-screen py-24 px-6">
+        <div className="container mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-display font-bold text-primary">Obra não encontrada</h1>
+          <p className="mt-4 text-muted-foreground">
+            Esta obra não está disponível. Que tal voltar para o portfolio e descobrir outras experiências?
+          </p>
+          <Button asChild className="mt-8 rounded-full">
+            <Link to="/portfolio">Explorar portfolio</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const handleLightbox = (media: string | null) => {
+    setLightboxMedia(media);
+  };
+
+  return (
+    <div className="min-h-screen py-24 px-6">
+      <div className="container mx-auto max-w-4xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="rounded-3xl border border-border/70 bg-card/70 p-8 shadow-[0_45px_85px_-70px_rgba(124,58,237,0.85)] backdrop-blur-xl"
+        >
+          <Button
+            asChild
+            variant="ghost"
+            className="mb-6 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+          >
+            <Link to="/portfolio">
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Voltar para o portfolio
+            </Link>
+          </Button>
+
+          <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              {artwork.year}
+            </span>
+            {artwork.materials.map((material) => (
+              <Badge key={material} variant="outline" className="border-border/60 text-muted-foreground">
+                {material}
+              </Badge>
+            ))}
+          </div>
+
+          <h1 className="mt-6 text-4xl font-display font-semibold text-foreground">{artwork.title}</h1>
+
+          <p className="mt-4 text-lg text-muted-foreground/90">{artwork.description}</p>
+
+          {artwork.media?.length > 0 && (
+            <div className="mt-10 grid gap-6 md:grid-cols-2">
+              {artwork.media.map((media, index) => (
+                <button
+                  key={media}
+                  type="button"
+                  onClick={() => handleLightbox(media)}
+                  className="group relative overflow-hidden rounded-3xl border border-border/60 bg-background/60 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                >
+                  <img
+                    src={media}
+                    alt={`${artwork.title} – visual ${index + 1}`}
+                    width={640}
+                    height={360}
+                    loading="lazy"
+                    className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+                  />
+                  <span className="absolute inset-x-4 bottom-4 inline-flex items-center justify-between rounded-full border border-border/60 bg-background/70 px-4 py-1.5 text-xs font-semibold text-foreground">
+                    Ampliar visual
+                    <Maximize2 className="h-3.5 w-3.5" aria-hidden />
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {artwork.url3d && (
+            <div className="mt-10 rounded-3xl border border-border/60 bg-background/60 p-6">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Experiência imersiva</p>
+                  <p className="text-base text-muted-foreground/90">
+                    Abre uma prévia 3D com controles orbitais diretamente no browser.
+                  </p>
+                </div>
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <Button
+                    variant="outline"
+                    className="rounded-full border-border/70"
+                    onClick={() => setShow3D(true)}
+                  >
+                    Pré-visualizar em 3D
+                  </Button>
+                  <Button asChild className="rounded-full bg-gradient-to-r from-primary via-secondary to-accent">
+                    <a href={artwork.url3d} target="_blank" rel="noopener noreferrer">
+                      Visitar projeto completo
+                      <ExternalLink className="ml-2 h-4 w-4" aria-hidden />
+                    </a>
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </motion.div>
+      </div>
+
+      <Dialog open={lightboxMedia !== null} onOpenChange={(open) => !open && handleLightbox(null)}>
+        <DialogContent className="max-w-3xl rounded-3xl border border-border/70 bg-card/95 p-0">
+          {lightboxMedia && (
+            <img
+              src={lightboxMedia}
+              alt={`${artwork.title} – visual ampliado`}
+              width={960}
+              height={540}
+              className="h-full w-full rounded-3xl object-contain"
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={show3D} onOpenChange={setShow3D}>
+        <DialogContent className="max-w-4xl rounded-3xl border border-border/70 bg-card/95">
+          <Suspense
+            fallback={
+              <div className="flex h-[320px] items-center justify-center text-sm text-muted-foreground">
+                Carregando visualização 3D…
+              </div>
+            }
+          >
+            {show3D ? <ArtworkPreview3D /> : null}
+          </Suspense>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,8 +1,10 @@
 import { motion, useReducedMotion } from 'framer-motion';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, Sparkles } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import cvData from '../../public/data/cv.json';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 
 export default function Portfolio() {
   const [filter, setFilter] = useState<string>('Todos');
@@ -102,11 +104,11 @@ export default function Portfolio() {
                       <h3 className="text-2xl font-display font-bold group-hover:text-primary transition-colors">
                         {project.name}
                       </h3>
-                      <span className="text-xs font-medium px-3 py-1 rounded-full bg-muted text-muted-foreground whitespace-nowrap ml-2">
-                      {project.category}
-                    </span>
-                  </div>
-                  
+                      <span className="ml-2 inline-flex items-center rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        {project.category}
+                      </span>
+                    </div>
+
                     <p className="text-muted-foreground flex-1 text-sm leading-relaxed">
                       {project.summary}
                     </p>
@@ -137,6 +139,77 @@ export default function Portfolio() {
             </motion.div>
           ))}
         </div>
+
+        {cvData.series?.length ? (
+          <motion.section
+            initial={prefersReducedMotion ? undefined : { opacity: 0, y: 28 }}
+            whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: '-80px' }}
+            transition={{ duration: 0.6 }}
+            className="mt-20 rounded-3xl border border-border/60 bg-card/70 p-8 shadow-[0_35px_70px_-60px_rgba(56,189,248,0.75)]"
+          >
+            <div className="mb-8 flex flex-col gap-3 text-center">
+              <span className="mx-auto inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
+                <Sparkles className="h-3 w-3" aria-hidden />
+                Séries criativas
+              </span>
+              <h2 className="text-3xl font-display font-semibold text-foreground">Coleções que contam histórias</h2>
+              <p className="text-base text-muted-foreground/80">
+                Cada série reúne obras, interfaces e experiências que dialogam entre si.
+              </p>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              {cvData.series.map((series) => {
+                const artworks = (series.works ?? [])
+                  .map((slug) => cvData.artworks?.find((art) => art.slug === slug))
+                  .filter((item): item is (typeof cvData.artworks)[number] => Boolean(item));
+
+                return (
+                  <motion.article
+                    key={series.slug}
+                    initial={prefersReducedMotion ? undefined : { opacity: 0, y: 16 }}
+                    whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ duration: 0.4 }}
+                    className="group flex flex-col rounded-3xl border border-border/60 bg-background/60 p-6 shadow-[0_25px_55px_-45px_rgba(124,58,237,0.75)]"
+                  >
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-2xl font-display font-semibold text-foreground group-hover:text-primary transition-colors">
+                        {series.title}
+                      </h3>
+                      <span className="rounded-full border border-border/60 bg-card/60 px-3 py-1 text-xs font-medium text-muted-foreground">
+                        {series.year}
+                      </span>
+                    </div>
+
+                    <p className="mt-3 flex-1 text-sm text-muted-foreground/90">{series.description}</p>
+
+                    {artworks.length > 0 && (
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {artworks.map((art) => (
+                          <Badge key={art.slug} variant="outline" className="border-border/60 text-muted-foreground">
+                            {art.title}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="mt-6">
+                      <Link
+                        to={`/series/${series.slug}`}
+                        className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/60 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      >
+                        Ver coleção completa
+                        <ExternalLink className="h-4 w-4" aria-hidden />
+                      </Link>
+                    </div>
+                  </motion.article>
+                );
+              })}
+            </div>
+          </motion.section>
+        ) : null}
 
         {filteredProjects.length === 0 && (
           <motion.div

--- a/src/pages/SeriesDetail.tsx
+++ b/src/pages/SeriesDetail.tsx
@@ -1,0 +1,127 @@
+import { Link, useParams } from 'react-router-dom';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, Sparkles, ArrowRight } from 'lucide-react';
+import cvData from '../../public/data/cv.json';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+export default function SeriesDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const prefersReducedMotion = useReducedMotion();
+  const series = cvData.series?.find((item) => item.slug === slug);
+
+  if (!series) {
+    return (
+      <div className="min-h-screen py-24 px-6">
+        <div className="container mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-display font-bold text-primary">Série não encontrada</h1>
+          <p className="mt-4 text-muted-foreground">
+            Não foi possível localizar esta série criativa. Explora outros projetos no portfolio.
+          </p>
+          <Button asChild className="mt-8 rounded-full">
+            <Link to="/portfolio">Ver portfolio</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const artworks = (series.works ?? [])
+    .map((workSlug) => cvData.artworks?.find((art) => art.slug === workSlug))
+    .filter((item): item is (typeof cvData.artworks)[number] => Boolean(item));
+
+  return (
+    <div className="min-h-screen py-24 px-6">
+      <div className="container mx-auto max-w-5xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="rounded-3xl border border-border/70 bg-card/70 p-8 shadow-[0_35px_70px_-60px_rgba(56,189,248,0.75)] backdrop-blur-xl"
+        >
+          <Button
+            asChild
+            variant="ghost"
+            className="mb-6 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+          >
+            <Link to="/portfolio">
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Voltar para o portfolio
+            </Link>
+          </Button>
+
+          <div className="flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              <Sparkles className="h-3 w-3" aria-hidden />
+              Série criativa
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              Ano {series.year}
+            </span>
+          </div>
+
+          <h1 className="mt-6 text-4xl font-display font-semibold text-foreground">
+            {series.title}
+          </h1>
+
+          <p className="mt-4 text-lg text-muted-foreground/90">{series.description}</p>
+
+          {artworks.length > 0 && (
+            <div className="mt-10 space-y-6">
+              <h2 className="text-2xl font-display font-semibold text-foreground">Peças em destaque</h2>
+              <div className="grid gap-6 md:grid-cols-2">
+                {artworks.map((art, index) => (
+                  <motion.article
+                    key={art.slug}
+                    initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+                    animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.08, duration: 0.4 }}
+                    className="group flex flex-col rounded-3xl border border-border/60 bg-background/60 p-6 shadow-[0_25px_55px_-45px_rgba(124,58,237,0.75)]"
+                  >
+                    <div className="relative mb-4 overflow-hidden rounded-2xl border border-border/50 bg-card/60">
+                      <img
+                        src={art.media[0]}
+                        alt={`${art.title} – visual principal`}
+                        width={640}
+                        height={360}
+                        loading="lazy"
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground uppercase tracking-wide">
+                      <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                        {art.year}
+                      </span>
+                      {art.materials.map((material) => (
+                        <Badge key={material} variant="outline" className="border-border/60 text-muted-foreground">
+                          {material}
+                        </Badge>
+                      ))}
+                    </div>
+
+                    <h3 className="mt-4 text-2xl font-display font-semibold text-foreground group-hover:text-primary transition-colors">
+                      {art.title}
+                    </h3>
+
+                    <p className="mt-3 text-sm text-muted-foreground/90">{art.description}</p>
+
+                    <div className="mt-auto pt-6">
+                      <Link
+                        to={`/art/${art.slug}`}
+                        className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card/60 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                      >
+                        Explorar obra
+                        <ArrowRight className="h-4 w-4" aria-hidden />
+                      </Link>
+                    </div>
+                  </motion.article>
+                ))}
+              </div>
+            </div>
+          )}
+        </motion.div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated series and artwork routes fed by cv.json data with accessible layouts
- introduce a lazy 3D artwork preview component that respects reduced motion and pauses when hidden
- extend the portfolio grid with a creative series section linking to the new detail experiences

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a7dd248083229c80c886e03f0b34