### PR TITLE
Add locale aware storytelling pages and art showcases

### DIFF
--- a/public/data/cv.json
+++ b/public/data/cv.json
@@ -16,6 +16,7 @@
   },
   "projects": [
     {
+      "slug": "monynha-com",
       "name": "Monynha.com",
       "summary": "Website institucional da Monynha Softwares — vitrine de produtos, valores e visão da marca.",
       "stack": ["Next.js", "TailwindCSS", "Payload CMS", "Supabase"],
@@ -25,6 +26,7 @@
       "year": 2024
     },
     {
+      "slug": "monynha-tech",
       "name": "Monynha Tech",
       "summary": "Blog técnico e central de documentação dos projetos Monynha. Plataforma voltada para desenvolvedores e estudantes.",
       "stack": ["Next.js", "Supabase", "CI/CD", "Markdown"],
@@ -34,6 +36,7 @@
       "year": 2025
     },
     {
+      "slug": "facodi",
       "name": "FACODI",
       "summary": "Faculdade Comunitária Digital — portal gratuito de ensino superior aberto e colaborativo, alimentado por currículos oficiais e conteúdo público.",
       "stack": ["Next.js", "Supabase", "Payload CMS"],
@@ -43,6 +46,7 @@
       "year": 2025
     },
     {
+      "slug": "boteco-pro",
       "name": "Boteco Pro",
       "summary": "Aplicativo de gestão para bares e restaurantes, desenvolvido em Flutter e Supabase.",
       "stack": ["Flutter", "Supabase", "PostgreSQL"],
@@ -52,6 +56,7 @@
       "year": 2025
     },
     {
+      "slug": "art-leo",
       "name": "Art Leo",
       "summary": "Website 3D imersivo para o artista Leonardo Silva, explorando arte, animação e interação digital.",
       "stack": ["Next.js", "react-three-fiber", "Supabase"],
@@ -61,6 +66,7 @@
       "year": 2025
     },
     {
+      "slug": "monagent",
       "name": "Monagent",
       "summary": "Framework modular em Python para criação de agentes de IA e integração com automações (n8n, APIs, ferramentas de dados).",
       "stack": ["Python", "FastAPI", "n8n", "Supabase"],
@@ -130,12 +136,16 @@
   "thoughts": [
     {
       "slug": "design-tecnologia-inclusiva",
+      "date": "2025-01-17",
+      "tags": ["Acessibilidade", "Design", "Experiência do utilizador"],
       "title": "Design e Tecnologia Inclusiva",
       "excerpt": "A tecnologia é mais humana quando é acessível.",
       "body": "Acredito que design e acessibilidade não são opostos, mas aliados. No ecossistema Monynha, cada interface nasce com empatia: contraste adequado, navegação por teclado e respeito ao prefers-reduced-motion fazem parte do nosso DNA digital."
     },
     {
       "slug": "por-tras-da-monynha",
+      "date": "2025-02-02",
+      "tags": ["Cultura", "Comunidade", "Empreendedorismo"],
       "title": "Por trás da Monynha",
       "excerpt": "Mais do que software, é movimento.",
       "body": "Monynha Softwares nasceu da vontade de unir diversidade e tecnologia em um só propósito: criar ferramentas que empoderem pessoas e transformem ideias em experiências digitais acessíveis, criativas e babadeiras 💅."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ const Portfolio = lazy(() => import("./pages/Portfolio"));
 const About = lazy(() => import("./pages/About"));
 const Thoughts = lazy(() => import("./pages/Thoughts"));
 const ThoughtDetail = lazy(() => import("./pages/ThoughtDetail"));
+const SeriesDetail = lazy(() => import("./pages/SeriesDetail"));
+const ArtDetail = lazy(() => import("./pages/ArtDetail"));
 const Contact = lazy(() => import("./pages/Contact"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
@@ -61,6 +63,8 @@ const App = () => {
               <Route path="/about" element={<About />} />
               <Route path="/thoughts" element={<Thoughts />} />
               <Route path="/thoughts/:slug" element={<ThoughtDetail />} />
+              <Route path="/series/:slug" element={<SeriesDetail />} />
+              <Route path="/art/:slug" element={<ArtDetail />} />
               <Route path="/contact" element={<Contact />} />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/components/Art3DPreview.tsx
+++ b/src/components/Art3DPreview.tsx
@@ -1,0 +1,71 @@
+import { Suspense, useEffect, useRef, type MutableRefObject } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, MeshDistortMaterial } from '@react-three/drei';
+import { Mesh } from 'three';
+
+const useVisibilityController = () => {
+  const visibleRef = useRef(true);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      visibleRef.current = !document.hidden;
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
+
+  return visibleRef;
+};
+
+const RibbonSculpture = ({ visibleRef }: { visibleRef: MutableRefObject<boolean> }) => {
+  const meshRef = useRef<Mesh>(null);
+  const lastFrame = useRef(0);
+
+  useFrame(({ clock }) => {
+    if (!meshRef.current || !visibleRef.current) return;
+    const elapsed = clock.getElapsedTime();
+    if (elapsed - lastFrame.current < 1 / 48) return;
+    lastFrame.current = elapsed;
+
+    meshRef.current.rotation.y = elapsed * 0.35;
+    meshRef.current.rotation.x = Math.sin(elapsed * 0.6) * 0.3;
+  });
+
+  return (
+    <mesh ref={meshRef} scale={1.8} position={[0, 0, 0]}>
+      <torusKnotGeometry args={[0.85, 0.28, 200, 32, 2, 3]} />
+      <MeshDistortMaterial
+        color="#a855f7"
+        emissive="#0ea5e9"
+        emissiveIntensity={0.45}
+        metalness={0.75}
+        roughness={0.25}
+        distort={0.4}
+        speed={1}
+      />
+    </mesh>
+  );
+};
+
+const Art3DPreview = () => {
+  const visibleRef = useVisibilityController();
+
+  return (
+    <Canvas
+      camera={{ position: [0, 0, 4.5], fov: 45 }}
+      dpr={[1, 1.6]}
+      gl={{ antialias: true, alpha: true, powerPreference: 'high-performance' }}
+    >
+      <Suspense fallback={null}>
+        <ambientLight intensity={0.6} />
+        <directionalLight position={[4, 6, 5]} intensity={1.2} color="#7c3aed" />
+        <pointLight position={[-4, -3, -4]} intensity={0.8} color="#22d3ee" />
+        <RibbonSculpture visibleRef={visibleRef} />
+        <OrbitControls enablePan={false} enableZoom enableDamping dampingFactor={0.08} />
+      </Suspense>
+    </Canvas>
+  );
+};
+
+export default Art3DPreview;

--- a/src/hooks/useCurrentLanguage.ts
+++ b/src/hooks/useCurrentLanguage.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import {
+  detectInitialLanguage,
+  type SupportedLanguage,
+} from '@/lib/googleTranslate';
+
+const LANGUAGE_EVENT = 'monynha:languagechange';
+
+export const useCurrentLanguage = () => {
+  const [language, setLanguage] = useState<SupportedLanguage>(
+    detectInitialLanguage(),
+  );
+
+  useEffect(() => {
+    const handle = (event: Event) => {
+      const detail = (event as CustomEvent<SupportedLanguage>).detail;
+      if (detail) {
+        setLanguage(detail);
+      }
+    };
+
+    window.addEventListener(LANGUAGE_EVENT, handle);
+    return () => window.removeEventListener(LANGUAGE_EVENT, handle);
+  }, []);
+
+  return language;
+};
+
+export const languageToLocale = (language: SupportedLanguage) => {
+  switch (language) {
+    case 'en':
+      return 'en-US';
+    case 'es':
+      return 'es-ES';
+    case 'fr':
+      return 'fr-FR';
+    case 'pt':
+    default:
+      return 'pt-PT';
+  }
+};

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,0 +1,4 @@
+export const calculateReadingTime = (content: string, wordsPerMinute = 180) => {
+  const words = content.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / wordsPerMinute));
+};

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,14 +1,16 @@
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { MapPin, Briefcase, Award } from 'lucide-react';
 import cvData from '../../public/data/cv.json';
 
 export default function About() {
+  const prefersReducedMotion = useReducedMotion();
+
   return (
     <div className="min-h-screen pt-24 pb-16">
       <div className="container mx-auto px-6 max-w-5xl">
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
           className="text-center mb-16"
         >
@@ -22,8 +24,8 @@ export default function About() {
 
         {/* Profile Section */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.6 }}
           className="glass rounded-2xl p-8 md:p-12 mb-12"
         >
@@ -56,8 +58,8 @@ export default function About() {
 
         {/* Experience Section */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ delay: 0.4, duration: 0.6 }}
           className="mb-12"
         >
@@ -70,8 +72,10 @@ export default function About() {
             {cvData.experience.map((exp, index) => (
               <motion.div
                 key={index}
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
+                initial={
+                  prefersReducedMotion ? undefined : { opacity: 0, x: -20 }
+                }
+                animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
                 transition={{ delay: 0.5 + index * 0.1, duration: 0.5 }}
                 className="glass rounded-2xl p-6 hover:shadow-lg hover:shadow-primary/10 transition-all"
               >
@@ -106,8 +110,8 @@ export default function About() {
 
         {/* Skills Section */}
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ delay: 0.6, duration: 0.6 }}
         >
           <div className="flex items-center gap-3 mb-6">
@@ -119,8 +123,10 @@ export default function About() {
             {cvData.skills.map((skill, index) => (
               <motion.div
                 key={skill.name}
-                initial={{ opacity: 0, scale: 0.9 }}
-                animate={{ opacity: 1, scale: 1 }}
+                initial={
+                  prefersReducedMotion ? undefined : { opacity: 0, scale: 0.9 }
+                }
+                animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
                 transition={{ delay: 0.7 + index * 0.05, duration: 0.3 }}
                 className="glass rounded-2xl p-4 flex items-center justify-between hover:shadow-md transition-shadow"
               >

--- a/src/pages/ArtDetail.tsx
+++ b/src/pages/ArtDetail.tsx
@@ -1,0 +1,194 @@
+import { useState, Suspense, lazy } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, ExternalLink, Maximize2, Orbit } from 'lucide-react';
+import cvData from '../../public/data/cv.json';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  languageToLocale,
+  useCurrentLanguage,
+} from '@/hooks/useCurrentLanguage';
+
+const Art3DPreview = lazy(() => import('@/components/Art3DPreview'));
+
+export default function ArtDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const prefersReducedMotion = useReducedMotion();
+  const language = useCurrentLanguage();
+  const locale = languageToLocale(language);
+  const artwork = cvData.artworks.find((item) => item.slug === slug);
+  const [isMediaOpen, setIsMediaOpen] = useState(false);
+  const [activeMedia, setActiveMedia] = useState<string | null>(null);
+  const [is3DOpen, setIs3DOpen] = useState(false);
+
+  const handleOpenMedia = (media: string) => {
+    setActiveMedia(media);
+    setIsMediaOpen(true);
+  };
+
+  if (!artwork) {
+    return (
+      <div className="min-h-screen py-24 px-6">
+        <div className="container mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-display font-bold text-primary">Obra não encontrada</h1>
+          <p className="mt-4 text-muted-foreground">
+            Esta peça artística não existe ou foi movida. Volta ao portfolio para conhecer outras experiências digitais.
+          </p>
+          <Button asChild className="mt-8 rounded-full">
+            <Link to="/portfolio">Ver portfolio</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen py-24 px-6">
+      <div className="container mx-auto max-w-4xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="rounded-3xl border border-border/60 bg-card/70 p-10 shadow-[0_45px_90px_-70px_rgba(124,58,237,0.8)] backdrop-blur-xl"
+        >
+          <Button
+            asChild
+            variant="ghost"
+            className="mb-8 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+          >
+            <Link to="/portfolio">
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Voltar ao portfolio
+            </Link>
+          </Button>
+
+          <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              {new Intl.DateTimeFormat(locale, { year: 'numeric' }).format(
+                new Date(`${artwork.year}-01-01`),
+              )}
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              {artwork.materials.join(' • ')}
+            </span>
+          </div>
+
+          <h1 className="mt-6 text-4xl font-display font-semibold text-foreground">
+            {artwork.title}
+          </h1>
+
+          <p className="mt-4 text-lg text-muted-foreground/90">{artwork.description}</p>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-2">
+            {artwork.media.map((media, index) => (
+              <motion.button
+                key={`${media}-${index}`}
+                type="button"
+                onClick={() => handleOpenMedia(media)}
+                className="group relative overflow-hidden rounded-2xl border border-border/60 bg-card/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                initial={prefersReducedMotion ? undefined : { opacity: 0, y: 16 }}
+                animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                transition={{ duration: 0.4 }}
+              >
+                <img
+                  src={media}
+                  alt={`${artwork.title} — visual ${index + 1}`}
+                  loading="lazy"
+                  decoding="async"
+                  width={640}
+                  height={360}
+                  className="h-full w-full object-cover"
+                />
+                <div className="pointer-events-none absolute inset-0 flex items-end justify-end bg-gradient-to-t from-background/70 via-background/20 to-transparent p-4 opacity-0 transition group-hover:opacity-100">
+                  <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/80 px-3 py-1 text-xs font-medium text-muted-foreground">
+                    <Maximize2 className="h-3 w-3" aria-hidden />
+                    Expandir
+                  </span>
+                </div>
+              </motion.button>
+            ))}
+          </div>
+
+          {artwork.url3d && (
+            <div className="mt-10 flex flex-wrap items-center gap-4">
+              <Button
+                type="button"
+                onClick={() => setIs3DOpen(true)}
+                className="inline-flex items-center gap-2 rounded-full"
+              >
+                <Orbit className="h-4 w-4" aria-hidden />
+                Explorar experiência 3D
+              </Button>
+              <a
+                href={artwork.url3d}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full border border-border/60 px-4 py-2 text-sm text-muted-foreground transition hover:border-primary/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                Abrir em nova aba
+                <ExternalLink className="h-4 w-4" aria-hidden />
+              </a>
+            </div>
+          )}
+        </motion.div>
+      </div>
+
+      <Dialog open={isMediaOpen} onOpenChange={setIsMediaOpen}>
+        <DialogContent className="max-w-4xl border border-border/60 bg-card/90 backdrop-blur-xl">
+          <DialogHeader>
+            <DialogTitle>{artwork.title}</DialogTitle>
+            <DialogDescription>Visualização ampliada da obra.</DialogDescription>
+          </DialogHeader>
+          {typeof activeMedia === 'string' && (
+            <img
+              src={activeMedia}
+              alt={`${artwork.title} em detalhe`}
+              className="h-auto w-full rounded-2xl"
+              loading="lazy"
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {artwork.url3d && (
+        <Dialog open={is3DOpen} onOpenChange={setIs3DOpen}>
+          <DialogContent className="max-w-5xl border border-border/60 bg-card/90 backdrop-blur-xl">
+            <DialogHeader>
+              <DialogTitle>Exploração 3D</DialogTitle>
+              <DialogDescription>
+                Cena interativa da experiência Art Leo com controlo de órbita.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="h-[420px] w-full overflow-hidden rounded-2xl bg-background/80">
+              <Suspense
+                fallback={
+                  <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                    Carregando visualização 3D…
+                  </div>
+                }
+              >
+                {prefersReducedMotion ? (
+                  <div className="flex h-full flex-col items-center justify-center gap-4 text-muted-foreground">
+                    <Orbit className="h-6 w-6" aria-hidden />
+                    <p className="max-w-sm text-center text-sm">
+                      A visualização 3D está desativada porque a preferência do sistema indica movimento reduzido.
+                    </p>
+                  </div>
+                ) : (
+                  <Art3DPreview />
+                )}
+              </Suspense>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Mail, Github, Linkedin, Send } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
@@ -9,6 +9,7 @@ import cvData from '../../public/data/cv.json';
 import { supabase } from '@/lib/supabaseClient';
 
 export default function Contact() {
+  const prefersReducedMotion = useReducedMotion();
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -54,8 +55,8 @@ export default function Contact() {
     <div className="min-h-screen pt-24 pb-16">
       <div className="container mx-auto px-6 max-w-5xl">
         <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
           className="text-center mb-16"
         >
@@ -70,8 +71,8 @@ export default function Contact() {
         <div className="grid md:grid-cols-2 gap-12">
           {/* Contact Info */}
           <motion.div
-            initial={{ opacity: 0, x: -20 }}
-            animate={{ opacity: 1, x: 0 }}
+            initial={prefersReducedMotion ? undefined : { opacity: 0, x: -20 }}
+            animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
             transition={{ delay: 0.2, duration: 0.6 }}
             className="space-y-8"
           >
@@ -79,11 +80,11 @@ export default function Contact() {
               <h2 className="text-2xl font-display font-bold mb-6">
                 Informações de Contato
               </h2>
-              
+
               <div className="space-y-6">
                 <a
                   href={cvData.links.email}
-                  className="flex items-center gap-4 text-muted-foreground hover:text-primary transition-colors group"
+                  className="flex items-center gap-4 text-muted-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background group"
                 >
                   <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
                     <Mail className="text-primary" />
@@ -98,7 +99,7 @@ export default function Contact() {
                   href={cvData.links.github}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-4 text-muted-foreground hover:text-primary transition-colors group"
+                  className="flex items-center gap-4 text-muted-foreground transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background group"
                 >
                   <div className="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
                     <Github className="text-primary" />
@@ -113,7 +114,7 @@ export default function Contact() {
                   href={cvData.links.linkedin}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-4 text-muted-foreground hover:text-secondary transition-colors group"
+                  className="flex items-center gap-4 text-muted-foreground transition-colors hover:text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background group"
                 >
                   <div className="w-12 h-12 rounded-xl bg-secondary/10 flex items-center justify-center group-hover:bg-secondary/20 transition-colors">
                     <Linkedin className="text-secondary" />
@@ -136,8 +137,8 @@ export default function Contact() {
 
           {/* Contact Form */}
           <motion.div
-            initial={{ opacity: 0, x: 20 }}
-            animate={{ opacity: 1, x: 0 }}
+            initial={prefersReducedMotion ? undefined : { opacity: 0, x: 20 }}
+            animate={prefersReducedMotion ? undefined : { opacity: 1, x: 0 }}
             transition={{ delay: 0.4, duration: 0.6 }}
           >
             <form onSubmit={handleSubmit} className="glass rounded-2xl p-8">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from 'framer-motion';
-import { ArrowRight, Code2, Sparkles, PenSquare } from 'lucide-react';
+import { ArrowRight, Code2, Sparkles, PenSquare, Layers, Palette } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import Hero3D from '@/components/Hero3D';
@@ -188,6 +188,76 @@ export default function Home() {
               </Link>
             </Button>
           </motion.div>
+        </div>
+      </section>
+
+      {/* Collections & Art */}
+      <section className="pb-24 px-6">
+        <div className="container mx-auto">
+          <motion.div
+            initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+            whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+            className="mb-12 text-center"
+          >
+            <h2 className="text-4xl md:text-5xl font-display font-bold mb-4">
+              Coleções & Arte
+            </h2>
+            <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+              Experiências imersivas e séries experimentais que conectam tecnologia, narrativa e arte digital.
+            </p>
+          </motion.div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <motion.div
+              initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+              whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6, delay: 0.1 }}
+            >
+              <Link
+                to="/series/creative-systems"
+                className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                <div className="flex h-full flex-col rounded-3xl border border-border/70 bg-card/70 p-6 shadow-[0_30px_60px_-50px_rgba(56,189,248,0.7)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_55px_-35px_rgba(124,58,237,0.6)]">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-secondary via-primary to-accent text-white shadow-[0_0_20px_rgba(124,58,237,0.45)]">
+                    <Layers aria-hidden className="h-6 w-6" />
+                  </div>
+                  <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
+                    Creative Systems
+                  </h3>
+                  <p className="mt-3 text-sm text-muted-foreground/90">
+                    Coleção de trabalhos que explora IA aplicada, automação inteligente e interfaces artísticas conectadas ao laboratório Monynha.
+                  </p>
+                </div>
+              </Link>
+            </motion.div>
+
+            <motion.div
+              initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+              whileInView={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6, delay: 0.2 }}
+            >
+              <Link
+                to="/art/artleo"
+                className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                <div className="flex h-full flex-col rounded-3xl border border-border/70 bg-card/70 p-6 shadow-[0_30px_60px_-50px_rgba(124,58,237,0.7)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_55px_-35px_rgba(56,189,248,0.6)]">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary via-secondary to-accent text-white shadow-[0_0_20px_rgba(56,189,248,0.45)]">
+                    <Palette aria-hidden className="h-6 w-6" />
+                  </div>
+                  <h3 className="mt-6 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
+                    Art Leo Creative Spaces
+                  </h3>
+                  <p className="mt-3 text-sm text-muted-foreground/90">
+                    Experiência 3D com narrativas interativas e composição sonora inspirada nos espaços criativos de Leonardo Silva.
+                  </p>
+                </div>
+              </Link>
+            </motion.div>
+          </div>
         </div>
       </section>
     </div>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,22 +1,40 @@
-import { useLocation } from "react-router-dom";
-import { useEffect } from "react";
+import { Link, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { Button } from '@/components/ui/button';
 
 const NotFound = () => {
   const location = useLocation();
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
-    console.error("404 Error: User attempted to access non-existent route:", location.pathname);
+    console.error(
+      '404 Error: User attempted to access non-existent route:',
+      location.pathname,
+    );
   }, [location.pathname]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="mb-4 text-4xl font-bold">404</h1>
-        <p className="mb-4 text-xl text-gray-600">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 underline hover:text-blue-700">
-          Return to Home
-        </a>
-      </div>
+    <div className="flex min-h-screen items-center justify-center px-6 py-24">
+      <motion.div
+        initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+        animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="w-full max-w-xl rounded-3xl border border-border/60 bg-card/70 p-10 text-center shadow-[0_45px_85px_-70px_rgba(56,189,248,0.65)] backdrop-blur-xl"
+        role="alert"
+        aria-live="assertive"
+      >
+        <p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Erro 404</p>
+        <h1 className="mt-4 text-5xl font-display font-bold">Página não encontrada</h1>
+        <p className="mt-4 text-base text-muted-foreground">
+          O caminho <span className="font-mono text-primary">{location.pathname}</span> não existe. Volta à página inicial para continuar a explorar o universo Monynha.
+        </p>
+        <div className="mt-8 flex justify-center">
+          <Button asChild className="rounded-full">
+            <Link to="/">Voltar para o início</Link>
+          </Button>
+        </div>
+      </motion.div>
     </div>
   );
 };

--- a/src/pages/SeriesDetail.tsx
+++ b/src/pages/SeriesDetail.tsx
@@ -1,0 +1,199 @@
+import { Link, useParams } from 'react-router-dom';
+import { motion, useReducedMotion } from 'framer-motion';
+import { ArrowLeft, Layers, ExternalLink } from 'lucide-react';
+import cvData from '../../public/data/cv.json';
+import { Button } from '@/components/ui/button';
+import {
+  languageToLocale,
+  useCurrentLanguage,
+} from '@/hooks/useCurrentLanguage';
+
+type WorkCard = {
+  slug: string;
+  title: string;
+  description: string;
+  href?: string;
+  isInternal: boolean;
+  thumbnail?: string;
+  badge: string;
+};
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+
+const buildWorkCards = (): Record<string, WorkCard> => {
+  const artworkMap = cvData.artworks.reduce<Record<string, WorkCard>>(
+    (acc, artwork) => {
+      acc[artwork.slug] = {
+        slug: artwork.slug,
+        title: artwork.title,
+        description: artwork.description,
+        href: `/art/${artwork.slug}`,
+        isInternal: true,
+        thumbnail: artwork.media?.[0],
+        badge: 'Arte digital',
+      };
+      return acc;
+    },
+    {},
+  );
+
+  const projectMap = cvData.projects.reduce<Record<string, WorkCard>>(
+    (acc, project) => {
+      const key = project.slug || slugify(project.name);
+      acc[key] = {
+        slug: key,
+        title: project.name,
+        description: project.summary,
+        href: project.url,
+        isInternal: false,
+        thumbnail: project.thumbnail,
+        badge: project.category,
+      };
+      return acc;
+    },
+    {},
+  );
+
+  return { ...projectMap, ...artworkMap };
+};
+
+const WORK_CARDS = buildWorkCards();
+
+export default function SeriesDetail() {
+  const { slug } = useParams<{ slug: string }>();
+  const prefersReducedMotion = useReducedMotion();
+  const language = useCurrentLanguage();
+  const locale = languageToLocale(language);
+  const series = cvData.series.find((entry) => entry.slug === slug);
+
+  if (!series) {
+    return (
+      <div className="min-h-screen py-24 px-6">
+        <div className="container mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-display font-bold text-primary">Série não encontrada</h1>
+          <p className="mt-4 text-muted-foreground">
+            A coleção que procuras não está disponível. Volta ao portfolio e explora outras experiências criativas.
+          </p>
+          <Button asChild className="mt-8 rounded-full">
+            <Link to="/portfolio">Ver portfolio</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const works: WorkCard[] = series.works
+    .map((workSlug) => WORK_CARDS[workSlug] || WORK_CARDS[slugify(workSlug)])
+    .filter((card): card is WorkCard => Boolean(card));
+
+  return (
+    <div className="min-h-screen py-24 px-6">
+      <div className="container mx-auto max-w-5xl">
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, y: 24 }}
+          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="rounded-3xl border border-border/60 bg-card/70 p-10 shadow-[0_45px_85px_-70px_rgba(124,58,237,0.75)] backdrop-blur-xl"
+        >
+          <Button
+            asChild
+            variant="ghost"
+            className="mb-8 inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-4 py-2 text-sm text-muted-foreground transition hover:text-primary"
+          >
+            <Link to="/portfolio">
+              <ArrowLeft className="h-4 w-4" aria-hidden />
+              Voltar ao portfolio
+            </Link>
+          </Button>
+
+          <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              <Layers className="h-4 w-4" aria-hidden />
+              Série criativa
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+              {new Intl.DateTimeFormat(locale, { year: 'numeric' }).format(
+                new Date(`${series.year}-01-01`),
+              )}
+            </span>
+          </div>
+
+          <h1 className="mt-6 text-4xl font-display font-semibold text-foreground">
+            {series.title}
+          </h1>
+
+          <p className="mt-4 text-lg text-muted-foreground/90">{series.description}</p>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-2">
+            {works.map((work, index) => {
+              const Wrapper = work.isInternal ? Link : 'a';
+              const wrapperProps = work.isInternal
+                ? { to: work.href ?? '#', role: 'link' }
+                : {
+                    href: work.href ?? '#',
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                  };
+
+              return (
+                <motion.div
+                  key={work.slug}
+                  initial={prefersReducedMotion ? undefined : { opacity: 0, y: 20 }}
+                  animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.08, duration: 0.5 }}
+                >
+                  <Wrapper
+                    {...(wrapperProps as any)}
+                    className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                  >
+                    <div className="flex h-full flex-col rounded-3xl border border-border/70 bg-card/70 p-6 shadow-[0_35px_70px_-55px_rgba(56,189,248,0.65)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_25px_55px_-35px_rgba(124,58,237,0.6)]">
+                      {work.thumbnail && (
+                        <div className="mb-4 overflow-hidden rounded-2xl bg-gradient-to-br from-primary/20 via-secondary/20 to-accent/20">
+                          <img
+                            src={work.thumbnail}
+                            alt={`Arte ${work.title}`}
+                            loading="lazy"
+                            decoding="async"
+                            width={640}
+                            height={360}
+                            className="h-40 w-full object-cover"
+                          />
+                        </div>
+                      )}
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground">
+                          {work.badge}
+                        </span>
+                        {work.href && !work.isInternal && (
+                          <ExternalLink className="h-4 w-4 text-muted-foreground group-hover:text-primary" aria-hidden />
+                        )}
+                      </div>
+                      <h2 className="mt-4 text-2xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
+                        {work.title}
+                      </h2>
+                      <p className="mt-3 text-sm text-muted-foreground/90">
+                        {work.description}
+                      </p>
+                    </div>
+                  </Wrapper>
+                </motion.div>
+              );
+            })}
+            {works.length === 0 && (
+              <div className="col-span-full rounded-3xl border border-border/60 bg-background/60 p-8 text-center text-sm text-muted-foreground">
+                Novas obras desta série serão adicionadas em breve.
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ThoughtDetail.tsx
+++ b/src/pages/ThoughtDetail.tsx
@@ -1,13 +1,20 @@
 import { Link, useParams } from 'react-router-dom';
 import { motion, useReducedMotion } from 'framer-motion';
-import { ArrowLeft, Calendar, BookOpen } from 'lucide-react';
+import { ArrowLeft, Calendar, BookOpen, Tag } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import cvData from '../../public/data/cv.json';
 import { Button } from '@/components/ui/button';
+import {
+  languageToLocale,
+  useCurrentLanguage,
+} from '@/hooks/useCurrentLanguage';
+import { calculateReadingTime } from '@/lib/content';
 
 export default function ThoughtDetail() {
   const { slug } = useParams<{ slug: string }>();
   const prefersReducedMotion = useReducedMotion();
+  const language = useCurrentLanguage();
+  const locale = languageToLocale(language);
   const thought = cvData.thoughts.find((item) => item.slug === slug);
 
   if (!thought) {
@@ -25,6 +32,13 @@ export default function ThoughtDetail() {
       </div>
     );
   }
+
+  const formattedDate = new Intl.DateTimeFormat(locale, {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(new Date(thought.date));
+  const readingTime = calculateReadingTime(thought.body);
 
   return (
     <div className="min-h-screen py-24 px-6">
@@ -49,11 +63,11 @@ export default function ThoughtDetail() {
           <div className="flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
             <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
               <Calendar className="h-3 w-3" aria-hidden />
-              Atualizado em 2025
+              {formattedDate}
             </span>
             <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
               <BookOpen className="h-3 w-3" aria-hidden />
-              Leitura de 3 min
+              {readingTime} min
             </span>
           </div>
 
@@ -63,9 +77,21 @@ export default function ThoughtDetail() {
 
           <p className="mt-4 text-lg text-muted-foreground/90">{thought.excerpt}</p>
 
-          <div className="mt-8 space-y-6 text-base leading-relaxed text-foreground/90 prose prose-invert prose-p:text-foreground/90 prose-strong:text-foreground">
-            <ReactMarkdown>{thought.body}</ReactMarkdown>
+          <div className="mt-6 flex flex-wrap gap-2" aria-label="Etiquetas desta reflexão">
+            {thought.tags.map((tag) => (
+              <span
+                key={`${thought.slug}-${tag}`}
+                className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground"
+              >
+                <Tag className="h-3 w-3" aria-hidden />
+                {tag}
+              </span>
+            ))}
           </div>
+
+          <article className="mt-8 space-y-6 text-base leading-relaxed text-foreground/90 prose prose-invert prose-p:text-foreground/90 prose-strong:text-foreground">
+            <ReactMarkdown>{thought.body}</ReactMarkdown>
+          </article>
 
           <footer className="mt-12 rounded-2xl border border-border/60 bg-background/60 p-6">
             <p className="text-sm uppercase tracking-[0.4em] text-muted-foreground">Escrito por</p>

--- a/src/pages/Thoughts.tsx
+++ b/src/pages/Thoughts.tsx
@@ -1,11 +1,18 @@
 import { motion, useReducedMotion } from 'framer-motion';
-import { ArrowLeft, Calendar, BookOpen, ArrowRight } from 'lucide-react';
+import { ArrowLeft, Calendar, BookOpen, ArrowRight, Tag } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import cvData from '../../public/data/cv.json';
+import {
+  languageToLocale,
+  useCurrentLanguage,
+} from '@/hooks/useCurrentLanguage';
+import { calculateReadingTime } from '@/lib/content';
 
 export default function Thoughts() {
   const prefersReducedMotion = useReducedMotion();
+  const language = useCurrentLanguage();
+  const locale = languageToLocale(language);
 
   return (
     <div className="min-h-screen py-24 px-6">
@@ -38,44 +45,65 @@ export default function Thoughts() {
           </header>
 
           <div className="grid gap-8 md:grid-cols-2">
-            {cvData.thoughts.map((thought, index) => (
-              <motion.article
-                key={thought.slug}
-                initial={prefersReducedMotion ? undefined : { opacity: 0, y: 30 }}
-                animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1, duration: 0.45 }}
-                className="group flex h-full flex-col rounded-3xl border border-border/70 bg-card/70 p-8 shadow-[0_35px_65px_-55px_rgba(124,58,237,0.75)] backdrop-blur-xl"
-              >
-                <div className="mb-6 flex items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
-                    <Calendar className="h-3 w-3" aria-hidden />
-                    Atualizado em 2025
-                  </span>
-                  <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
-                    <BookOpen className="h-3 w-3" aria-hidden />
-                    Leitura de 3 min
-                  </span>
-                </div>
+            {cvData.thoughts.map((thought, index) => {
+              const formattedDate = new Intl.DateTimeFormat(locale, {
+                day: '2-digit',
+                month: 'short',
+                year: 'numeric',
+              }).format(new Date(thought.date));
+              const readingTime = calculateReadingTime(thought.body);
 
-                <h2 className="text-3xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
-                  {thought.title}
-                </h2>
+              return (
+                <motion.article
+                  key={thought.slug}
+                  initial={prefersReducedMotion ? undefined : { opacity: 0, y: 30 }}
+                  animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.1, duration: 0.45 }}
+                  className="group flex h-full flex-col rounded-3xl border border-border/70 bg-card/70 p-8 shadow-[0_35px_65px_-55px_rgba(124,58,237,0.75)] backdrop-blur-xl"
+                >
+                  <div className="mb-6 flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                      <Calendar className="h-3 w-3" aria-hidden />
+                      {formattedDate}
+                    </span>
+                    <span className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1">
+                      <BookOpen className="h-3 w-3" aria-hidden />
+                      {readingTime} min
+                    </span>
+                  </div>
 
-                <p className="mt-4 text-base text-muted-foreground/90">
-                  {thought.excerpt}
-                </p>
+                  <h2 className="text-3xl font-display font-semibold text-foreground transition-colors group-hover:text-primary">
+                    {thought.title}
+                  </h2>
 
-                <div className="mt-auto pt-6">
-                  <Link
-                    to={`/thoughts/${thought.slug}`}
-                    className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary/70 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  >
-                    Ler reflexão completa
-                    <ArrowRight className="h-4 w-4" aria-hidden />
-                  </Link>
-                </div>
-              </motion.article>
-            ))}
+                  <p className="mt-4 text-base text-muted-foreground/90">
+                    {thought.excerpt}
+                  </p>
+
+                  <div className="mt-6 flex flex-wrap gap-2" aria-label="Etiquetas desta reflexão">
+                    {thought.tags.map((tag) => (
+                      <span
+                        key={`${thought.slug}-${tag}`}
+                        className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background/60 px-3 py-1 text-xs font-medium text-muted-foreground"
+                      >
+                        <Tag className="h-3 w-3" aria-hidden />
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+
+                  <div className="mt-auto pt-6">
+                    <Link
+                      to={`/thoughts/${thought.slug}`}
+                      className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm font-medium text-foreground transition hover:border-primary/70 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    >
+                      Ler reflexão completa
+                      <ArrowRight className="h-4 w-4" aria-hidden />
+                    </Link>
+                  </div>
+                </motion.article>
+              );
+            })}
           </div>
 
           <div className="mt-16 flex flex-col items-center gap-4 rounded-3xl border border-border/60 bg-background/40 p-8 text-center shadow-[0_35px_70px_-60px_rgba(56,189,248,0.7)]">


### PR DESCRIPTION
## Summary
- add project slugs plus dated, tagged thoughts metadata to the shared cv.json
- introduce language-aware blog listings/detail pages and new series/art detail routes with lazy 3D preview
- refresh supporting screens (home, about, contact, 404) with reduced-motion guards and improved accessibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3a7dd248083229c80c886e03f0b34