### PR TITLE
Harden Google Translate integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
   detectInitialLanguage,
   initializeGoogleTranslate,
   setLanguage,
+  cleanupGoogleTranslate,
 } from "./lib/googleTranslate";
 import type { SupportedLanguage } from "./lib/googleTranslate";
 
@@ -38,7 +39,10 @@ const App = () => {
     };
 
     window.addEventListener("storage", handleStorage);
-    return () => window.removeEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      cleanupGoogleTranslate();
+    };
   }, []);
 
   return (

--- a/src/lib/googleTranslate.ts
+++ b/src/lib/googleTranslate.ts
@@ -1,15 +1,15 @@
 const HIDE_SELECTORS = [
-  '.goog-te-banner-frame',
-  '.goog-te-gadget',
-  '.goog-te-gadget-simple',
-  '.goog-logo-link',
-  '.goog-te-combo',
-  'body > .skiptranslate',
+  ".goog-te-banner-frame",
+  ".goog-te-gadget",
+  ".goog-te-gadget-simple",
+  ".goog-logo-link",
+  ".goog-te-combo",
+  "body > .skiptranslate",
   'iframe[id^=":"]',
-  '#\\:1\\.container',
-];
+  "#\\:1\\.container",
+] as const;
 
-export const SUPPORTED_LANGUAGES = ['pt', 'en', 'es', 'fr'] as const;
+export const SUPPORTED_LANGUAGES = ["pt", "en", "es", "fr"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
 declare global {
@@ -19,50 +19,61 @@ declare global {
   }
 }
 
-const STORAGE_KEY = 'monynha-lang';
+const STORAGE_KEY = "monynha-lang";
 
 let pendingLanguage: SupportedLanguage | null = null;
 let comboObserver: MutationObserver | null = null;
 let hideObserver: MutationObserver | null = null;
+let hasInitialized = false;
 
-const isBrowser = () => typeof window !== 'undefined' && typeof document !== 'undefined';
+const isBrowser = () => typeof window !== "undefined" && typeof document !== "undefined";
 
-declare global {
-  interface Window {
-    setLanguage: (lang: SupportedLanguage) => void;
-    __afterGoogleTranslateInit?: () => void;
+const isDevelopment = () => {
+  try {
+    return Boolean((import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV);
+  } catch (error) {
+    return false;
   }
-}
+};
+
+const warn = (message: string, error?: unknown) => {
+  if (isDevelopment()) {
+    console.warn(`[googleTranslate] ${message}`, error);
+  }
+};
 
 const hideGoogleArtifacts = () => {
   if (!isBrowser()) return;
 
   HIDE_SELECTORS.forEach((selector) => {
     document.querySelectorAll<HTMLElement>(selector).forEach((element) => {
-      element.style.setProperty('display', 'none', 'important');
-      element.style.setProperty('visibility', 'hidden', 'important');
-      element.style.setProperty('opacity', '0', 'important');
-      element.setAttribute('aria-hidden', 'true');
-      element.setAttribute('tabindex', '-1');
+      element.style.setProperty("display", "none", "important");
+      element.style.setProperty("visibility", "hidden", "important");
+      element.style.setProperty("opacity", "0", "important");
+      element.setAttribute("aria-hidden", "true");
+      element.setAttribute("tabindex", "-1");
     });
   });
 
-  document.body?.style.setProperty('top', '0px', 'important');
+  document.body?.style.setProperty("top", "0px", "important");
 };
 
 const dispatchLanguageEvent = (lang: SupportedLanguage) => {
   if (!isBrowser()) return;
 
-  window.dispatchEvent(new CustomEvent<SupportedLanguage>('monynha:languagechange', { detail: lang }));
+  try {
+    window.dispatchEvent(new CustomEvent<SupportedLanguage>("monynha:languagechange", { detail: lang }));
+  } catch (error) {
+    warn("Unable to dispatch language change event", error);
+  }
 };
 
 const setDocumentLanguage = (lang: SupportedLanguage) => {
   if (!isBrowser()) return;
-  document.documentElement.setAttribute('lang', lang);
+  document.documentElement.setAttribute("lang", lang);
 };
 
-const getCombo = () =>
-  isBrowser() ? document.querySelector<HTMLSelectElement>('.goog-te-combo') : null;
+const getCombo = () => (isBrowser() ? document.querySelector<HTMLSelectElement>(".goog-te-combo") : null);
 
 const applyLanguageToCombo = (lang: SupportedLanguage) => {
   const combo = getCombo();
@@ -72,7 +83,7 @@ const applyLanguageToCombo = (lang: SupportedLanguage) => {
     combo.value = lang;
   }
 
-  combo.dispatchEvent(new Event('change'));
+  combo.dispatchEvent(new Event("change"));
   pendingLanguage = null;
   return true;
 };
@@ -91,21 +102,49 @@ const ensureComboObserver = () => {
     }
   });
 
-  comboObserver.observe(document.body, { childList: true, subtree: true });
+  try {
+    comboObserver.observe(document.body, { childList: true, subtree: true });
+  } catch (error) {
+    warn("Failed to observe Google translate combo", error);
+  }
 };
 
 const ensureHideObserver = () => {
   if (!isBrowser() || hideObserver) return;
 
   hideObserver = new MutationObserver(hideGoogleArtifacts);
-  hideObserver.observe(document.documentElement, {
-    childList: true,
-    subtree: true,
-  });
+  try {
+    hideObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+    });
+  } catch (error) {
+    warn("Failed to register observer to hide Google artifacts", error);
+  }
+};
+
+const getStoredLanguage = (): SupportedLanguage | null => {
+  if (!isBrowser()) return null;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return SUPPORTED_LANGUAGES.includes(stored as SupportedLanguage) ? (stored as SupportedLanguage) : null;
+  } catch (error) {
+    warn("Unable to access localStorage when reading language", error);
+    return null;
+  }
+};
+
+const setStoredLanguage = (lang: SupportedLanguage) => {
+  if (!isBrowser()) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, lang);
+  } catch (error) {
+    warn("Unable to persist language in localStorage", error);
+  }
 };
 
 export const initializeGoogleTranslate = () => {
-  if (!isBrowser()) return;
+  if (!isBrowser() || hasInitialized) return;
 
   hideGoogleArtifacts();
   ensureHideObserver();
@@ -118,14 +157,17 @@ export const initializeGoogleTranslate = () => {
       applyLanguageToCombo(pendingLanguage);
     }
   };
+
+  hasInitialized = true;
 };
 
 export const setLanguage = (lang: SupportedLanguage) => {
-  if (!SUPPORTED_LANGUAGES.includes(lang)) return;
-  if (!isBrowser()) return;
+  if (!SUPPORTED_LANGUAGES.includes(lang) || !isBrowser()) return;
+
+  if (pendingLanguage === lang) return;
 
   pendingLanguage = lang;
-  localStorage.setItem(STORAGE_KEY, lang);
+  setStoredLanguage(lang);
   setDocumentLanguage(lang);
   dispatchLanguageEvent(lang);
 
@@ -136,27 +178,23 @@ export const setLanguage = (lang: SupportedLanguage) => {
 };
 
 export const detectInitialLanguage = (): SupportedLanguage => {
-  if (!isBrowser()) return 'pt';
+  if (!isBrowser()) return "pt";
 
-  const stored = localStorage.getItem(STORAGE_KEY) as SupportedLanguage | null;
-  if (stored && SUPPORTED_LANGUAGES.includes(stored)) {
+  const stored = getStoredLanguage();
+  if (stored) {
     return stored;
   }
 
-  const navigatorLang = (navigator.language || navigator.languages?.[0] || 'pt')
-    .split('-')[0]
+  const navigatorLang = (navigator.language || navigator.languages?.[0] || "pt")
+    .split("-")[0]
     .toLowerCase() as SupportedLanguage;
 
   if (SUPPORTED_LANGUAGES.includes(navigatorLang)) {
     return navigatorLang;
   }
 
-  return 'pt';
+  return "pt";
 };
-
-if (isBrowser()) {
-  initializeGoogleTranslate();
-}
 
 export const cleanupGoogleTranslate = () => {
   if (comboObserver) {
@@ -167,4 +205,5 @@ export const cleanupGoogleTranslate = () => {
     hideObserver.disconnect();
     hideObserver = null;
   }
+  hasInitialized = false;
 };


### PR DESCRIPTION
## Summary
- make Google Translate initialization idempotent and guard DOM/localStorage access in non-browser contexts
- surface development warnings when the embedded widget fails and prevent leaking mutation observers on cleanup
- ensure the app un-registers Google Translate listeners when unmounting the root component

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e501503ef883228e55cd4d192dedab