### PR TITLE
Fix navigation blackout caused by Google Translate overlays

### DIFF
--- a/docs/navigation-fix-plan.md
+++ b/docs/navigation-fix-plan.md
@@ -1,0 +1,16 @@
+# Navigation Stability Fix Plan
+
+## Task 1 — Remove automatic Google Translate activation
+- **Goal:** Prevent the Google Translate widget from auto-triggering and injecting blocking overlays for visitors whose browsers are not set to Portuguese.
+- **Files/Components:** `index.html`, `src/components/LanguageSwitcher.tsx`.
+- **Expected Result:** The site loads without Google Translate altering the layout until a visitor explicitly chooses a language.
+
+## Task 2 — Manage Google Translate script inside React
+- **Goal:** Lazily load and initialise Google Translate from a reusable helper so that React retains control over the DOM tree and can recover from translation state changes.
+- **Files/Components:** `src/lib/googleTranslate.ts` (new), `src/components/LanguageSwitcher.tsx`.
+- **Expected Result:** Google Translate is initialised only once, integrates with the custom language switcher, and no longer wipes the app when navigating.
+
+## Task 3 — Guard against overlay interference
+- **Goal:** Ensure any Google Translate frames or containers cannot intercept pointer events or blank the viewport after navigation.
+- **Files/Components:** `src/lib/googleTranslate.ts`, `src/index.css`.
+- **Expected Result:** Navigation links remain clickable and the viewport never turns black after switching pages, even after changing languages.

--- a/index.html
+++ b/index.html
@@ -25,23 +25,6 @@
 
   <body>
     <div id="root"></div>
-    <div id="google_translate_element" style="display:none;"></div>
-    <script type="text/javascript">
-      function googleTranslateElementInit() {
-        new google.translate.TranslateElement({
-          pageLanguage: 'pt',
-          includedLanguages: 'pt,en,es,fr',
-          autoDisplay: false
-        }, 'google_translate_element');
-      }
-      window.setLanguage = function(lang) {
-        const combo = document.querySelector('.goog-te-combo');
-        if (!combo) return;
-        combo.value = lang;
-        combo.dispatchEvent(new Event('change'));
-      }
-    </script>
-    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -103,3 +103,26 @@ All colors MUST be HSL.
     @apply bg-background text-foreground;
   }
 }
+
+/* Google Translate overrides */
+body > .skiptranslate,
+body > .skiptranslate iframe,
+.goog-te-banner-frame.skiptranslate,
+.goog-te-menu-frame.skiptranslate,
+.VIpgJd-ZVi9od-ORHb-OEVmcd {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+}
+
+body > .skiptranslate,
+body > .skiptranslate *,
+.goog-te-menu-frame.skiptranslate,
+.VIpgJd-ZVi9od-ORHb-OEVmcd {
+  pointer-events: none !important;
+}
+
+html,
+body {
+  top: 0 !important;
+}

--- a/src/lib/googleTranslate.ts
+++ b/src/lib/googleTranslate.ts
@@ -1,0 +1,191 @@
+/*
+ * Utility helpers to integrate Google Translate without letting it take over the DOM tree.
+ * The helpers below lazy-load the script, expose a promise that resolves when the widget is
+ * ready, and make sure any of the injected overlays stay hidden so navigation keeps working.
+ */
+
+type TranslateConfig = {
+  defaultLanguage: string;
+  languages: string[];
+};
+
+type TranslateWindow = Window & {
+  google?: {
+    translate?: {
+      TranslateElement?: new (
+        options: Record<string, unknown>,
+        elementId: string,
+      ) => void;
+    };
+  };
+  googleTranslateElementInit?: () => void;
+};
+
+const getTranslateWindow = () => window as TranslateWindow;
+
+const SCRIPT_ID = "google-translate-script";
+const CONTAINER_ID = "google_translate_element";
+const CALLBACK_NAME = "googleTranslateElementInit";
+
+let initPromise: Promise<void> | null = null;
+
+const ensureContainer = () => {
+  if (typeof document === "undefined") return;
+  if (!document.getElementById(CONTAINER_ID)) {
+    const container = document.createElement("div");
+    container.id = CONTAINER_ID;
+    container.style.display = "none";
+    document.body.appendChild(container);
+  }
+};
+
+const updateCookie = (from: string, to: string) => {
+  if (typeof document === "undefined") return;
+  const value = `/${from}/${to}`;
+  const expires = new Date();
+  expires.setFullYear(expires.getFullYear() + 1);
+
+  document.cookie = `googtrans=${value};expires=${expires.toUTCString()};path=/`;
+
+  if (typeof window !== "undefined") {
+    const host = getTranslateWindow().location.hostname;
+    if (host.includes(".")) {
+      document.cookie = `googtrans=${value};expires=${expires.toUTCString()};path=/;domain=.${host}`;
+    }
+  }
+};
+
+export const cleanupGoogleTranslateArtifacts = () => {
+  if (typeof document === "undefined") return;
+
+  const hideSelectors = [
+    ".goog-logo-link",
+    ".goog-te-gadget",
+    ".goog-te-banner-frame",
+    ".goog-te-menu-frame",
+    ".goog-te-balloon-frame",
+  ];
+
+  hideSelectors.forEach((selector) => {
+    document.querySelectorAll(selector).forEach((element) => {
+      const el = element as HTMLElement;
+      el.style.display = "none";
+      el.style.visibility = "hidden";
+      el.style.opacity = "0";
+      el.style.pointerEvents = "none";
+    });
+  });
+
+  document.querySelectorAll(".skiptranslate, .VIpgJd-ZVi9od-ORHb-OEVmcd").forEach((element) => {
+    const el = element as HTMLElement;
+    el.style.pointerEvents = "none";
+    el.style.background = "transparent";
+    el.style.opacity = "0";
+  });
+
+  if (document.body) {
+    document.body.style.top = "0px";
+  }
+  if (document.documentElement) {
+    document.documentElement.style.top = "0px";
+  }
+};
+
+const initialiseWidget = (config: TranslateConfig, resolve: () => void) => {
+  const win = getTranslateWindow();
+  if (typeof win.google?.translate?.TranslateElement !== "function") {
+    resolve();
+    return;
+  }
+
+  ensureContainer();
+
+  // The widget re-creates the container every time, so protect against duplicates.
+  new win.google.translate.TranslateElement(
+    {
+      pageLanguage: config.defaultLanguage,
+      includedLanguages: config.languages.join(","),
+      autoDisplay: false,
+    },
+    CONTAINER_ID,
+  );
+
+  cleanupGoogleTranslateArtifacts();
+  resolve();
+};
+
+export const initGoogleTranslate = (config: TranslateConfig): Promise<void> => {
+  if (typeof window === "undefined") {
+    return Promise.resolve();
+  }
+
+  if (initPromise) {
+    return initPromise;
+  }
+
+  ensureContainer();
+
+  initPromise = new Promise<void>((resolve) => {
+    const win = getTranslateWindow();
+    const onReady = () => initialiseWidget(config, resolve);
+
+    win.googleTranslateElementInit = onReady;
+
+    if (typeof win.google?.translate?.TranslateElement === "function") {
+      onReady();
+      return;
+    }
+
+    const existingScript = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+    if (existingScript) {
+      existingScript.addEventListener("load", onReady, { once: true });
+      existingScript.addEventListener("error", () => resolve(), { once: true });
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = SCRIPT_ID;
+    script.src = `//translate.google.com/translate_a/element.js?cb=${CALLBACK_NAME}`;
+    script.async = true;
+    script.addEventListener("load", onReady, { once: true });
+    script.addEventListener("error", () => resolve(), { once: true });
+    document.body.appendChild(script);
+  });
+
+  return initPromise;
+};
+
+export const getGoogleTranslateLanguage = (defaultLanguage: string): string => {
+  if (typeof document === "undefined") return defaultLanguage;
+  const match = document.cookie.match(/googtrans=\/[^/]+\/([^;]+)/);
+  if (match && match[1]) {
+    return match[1];
+  }
+  if (typeof document.documentElement?.lang === "string" && document.documentElement.lang) {
+    return document.documentElement.lang;
+  }
+  return defaultLanguage;
+};
+
+export const setGoogleTranslateLanguage = (
+  language: string,
+  defaultLanguage: string,
+): boolean => {
+  if (typeof document === "undefined") return false;
+  const combo = document.querySelector<HTMLSelectElement>(".goog-te-combo");
+  if (!combo) return false;
+
+  if (combo.value !== language) {
+    combo.value = language;
+  }
+  combo.dispatchEvent(new Event("change"));
+
+  updateCookie(defaultLanguage, language);
+  cleanupGoogleTranslateArtifacts();
+
+  if (typeof document.documentElement !== "undefined") {
+    document.documentElement.setAttribute("lang", language);
+  }
+
+  return true;
+};


### PR DESCRIPTION
## Summary
- add a navigation fix plan outlining the debug tasks
- refactor the Google Translate integration to initialise lazily inside React and remember the current language
- hide injected Google Translate overlays so they cannot block navigation or blank the viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e501c389dc83229211b8409eadd4b8