### PR TITLE
Fix navigation blackout triggered by Google Translate

### DIFF
--- a/docs/bugfix-navigation-blackout.md
+++ b/docs/bugfix-navigation-blackout.md
@@ -1,0 +1,9 @@
+# Bugfix: Navigation Blackout
+
+## Root Cause
+
+Switching the interface language through Google Translate rewrites the DOM tree of the navigation bar. The animated highlight for the active route relied on `framer-motion`'s layout animations (`motion.span` with `layoutId`). When Google Translate injected its own nodes, the animation tried to move an element relative to a node that no longer existed, throwing `Failed to execute 'insertBefore' on 'Node'`. React consequently unmounted the tree and the user was left with a blank screen until a full refresh.
+
+## Fix
+
+Replaced the layout-driven highlight with a CSS-based gradient pill. The new implementation keeps the visual feedback but does not depend on `framer-motion` DOM re-parenting, so Google Translate can no longer interfere with navigation updates. The change keeps hover effects intact and preserves translation compatibility across all routes and languages.

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -46,7 +46,7 @@ export default function Navbar() {
                 <MotionLink
                   key={link.href}
                   to={link.href}
-                  className={`relative rounded-full px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+                  className={`relative overflow-hidden rounded-full px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-secondary focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
                     active ? 'text-white' : 'text-muted-foreground'
                   }`}
                   {...(!shouldReduceMotion
@@ -59,13 +59,13 @@ export default function Navbar() {
                       }
                     : {})}
                 >
-                  {active && (
-                    <motion.span
-                      layoutId="nav-pill"
-                      className="absolute inset-0 -z-10 rounded-full bg-gradient-to-r from-primary/90 via-secondary/80 to-accent/80"
-                      transition={{ type: 'spring', stiffness: 260, damping: 30 }}
-                    />
-                  )}
+                  <span
+                    aria-hidden
+                    translate="no"
+                    className={`pointer-events-none absolute inset-0 -z-10 rounded-full bg-gradient-to-r from-primary/90 via-secondary/80 to-accent/80 transition-all duration-200 ${
+                      active ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
+                    }`}
+                  />
                   {link.label}
                 </MotionLink>
               );


### PR DESCRIPTION
## Summary
- replace the navigation pill animation with a CSS transition so Google Translate mutations do not break routing
- add documentation summarizing the blackout root cause and fix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e50195399483228c297847d938bd61