### PR TITLE
Fix duplicate Google Translate import in App component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ import {
   detectInitialLanguage,
   initializeGoogleTranslate,
   setLanguage,
-  cleanupGoogleTranslate,
 } from "./lib/googleTranslate";
 import type { SupportedLanguage } from "./lib/googleTranslate";
 


### PR DESCRIPTION
## Summary
- remove the duplicate `cleanupGoogleTranslate` import from `App.tsx`
- ensure the Google Translate helpers are imported only once to avoid compilation errors

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e563313728832297fae1d77910ed59