### PR TITLE
Switch hero background to grid distortion effect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
+        "ogl": "^1.0.11",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -6879,6 +6880,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/ogl": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ogl/-/ogl-1.0.11.tgz",
+      "integrity": "sha512-kUpC154AFfxi16pmZUK4jk3J+8zxwTWGPo03EoYA8QPbzikHoaC82n6pNTbd+oEaJonaE8aPWBlX7ad9zrqLsA==",
+      "license": "Unlicense"
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
+    "ogl": "^1.0.11",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/src/components/FaultyTerminal.tsx
+++ b/src/components/FaultyTerminal.tsx
@@ -1,0 +1,429 @@
+import { Renderer, Program, Mesh, Color, Triangle } from 'ogl';
+import React, { useEffect, useRef, useMemo, useCallback } from 'react';
+
+type Vec2 = [number, number];
+
+export interface FaultyTerminalProps extends React.HTMLAttributes<HTMLDivElement> {
+  scale?: number;
+  gridMul?: Vec2;
+  digitSize?: number;
+  timeScale?: number;
+  pause?: boolean;
+  scanlineIntensity?: number;
+  glitchAmount?: number;
+  flickerAmount?: number;
+  noiseAmp?: number;
+  chromaticAberration?: number;
+  dither?: number | boolean;
+  curvature?: number;
+  tint?: string;
+  mouseReact?: boolean;
+  mouseStrength?: number;
+  dpr?: number;
+  pageLoadAnimation?: boolean;
+  brightness?: number;
+}
+
+const vertexShader = `
+attribute vec2 position;
+attribute vec2 uv;
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+`;
+
+const fragmentShader = `
+precision mediump float;
+
+varying vec2 vUv;
+
+uniform float iTime;
+uniform vec3  iResolution;
+uniform float uScale;
+
+uniform vec2  uGridMul;
+uniform float uDigitSize;
+uniform float uScanlineIntensity;
+uniform float uGlitchAmount;
+uniform float uFlickerAmount;
+uniform float uNoiseAmp;
+uniform float uChromaticAberration;
+uniform float uDither;
+uniform float uCurvature;
+uniform vec3  uTint;
+uniform vec2  uMouse;
+uniform float uMouseStrength;
+uniform float uUseMouse;
+uniform float uPageLoadProgress;
+uniform float uUsePageLoadAnimation;
+uniform float uBrightness;
+
+float time;
+
+float hash21(vec2 p){
+  p = fract(p * 234.56);
+  p += dot(p, p + 34.56);
+  return fract(p.x * p.y);
+}
+
+float noise(vec2 p)
+{
+  return sin(p.x * 10.0) * sin(p.y * (3.0 + sin(time * 0.090909))) + 0.2; 
+}
+
+mat2 rotate(float angle)
+{
+  float c = cos(angle);
+  float s = sin(angle);
+  return mat2(c, -s, s, c);
+}
+
+float fbm(vec2 p)
+{
+  p *= 1.1;
+  float f = 0.0;
+  float amp = 0.5 * uNoiseAmp;
+  
+  mat2 modify0 = rotate(time * 0.02);
+  f += amp * noise(p);
+  p = modify0 * p * 2.0;
+  amp *= 0.454545;
+  
+  mat2 modify1 = rotate(time * 0.02);
+  f += amp * noise(p);
+  p = modify1 * p * 2.0;
+  amp *= 0.454545;
+  
+  mat2 modify2 = rotate(time * 0.08);
+  f += amp * noise(p);
+  
+  return f;
+}
+
+float pattern(vec2 p, out vec2 q, out vec2 r) {
+  vec2 offset1 = vec2(1.0);
+  vec2 offset0 = vec2(0.0);
+  mat2 rot01 = rotate(0.1 * time);
+  mat2 rot1 = rotate(0.1);
+  
+  q = vec2(fbm(p + offset1), fbm(rot01 * p + offset1));
+  r = vec2(fbm(rot1 * q + offset0), fbm(q + offset0));
+  return fbm(p + r);
+}
+
+float digit(vec2 p){
+    vec2 grid = uGridMul * 15.0;
+    vec2 s = floor(p * grid) / grid;
+    p = p * grid;
+    vec2 q, r;
+    float intensity = pattern(s * 0.1, q, r) * 1.3 - 0.03;
+    
+    if(uUseMouse > 0.5){
+        vec2 mouseWorld = uMouse * uScale;
+        float distToMouse = distance(s, mouseWorld);
+        float mouseInfluence = exp(-distToMouse * 8.0) * uMouseStrength * 10.0;
+        intensity += mouseInfluence;
+        
+        float ripple = sin(distToMouse * 20.0 - iTime * 5.0) * 0.1 * mouseInfluence;
+        intensity += ripple;
+    }
+    
+    if(uUsePageLoadAnimation > 0.5){
+        float cellRandom = fract(sin(dot(s, vec2(12.9898, 78.233))) * 43758.5453);
+        float cellDelay = cellRandom * 0.8;
+        float cellProgress = clamp((uPageLoadProgress - cellDelay) / 0.2, 0.0, 1.0);
+        
+        float fadeAlpha = smoothstep(0.0, 1.0, cellProgress);
+        intensity *= fadeAlpha;
+    }
+    
+    p = fract(p);
+    p *= uDigitSize;
+    
+    float px5 = p.x * 5.0;
+    float py5 = (1.0 - p.y) * 5.0;
+    float x = fract(px5);
+    float y = fract(py5);
+    
+    float i = floor(py5) - 2.0;
+    float j = floor(px5) - 2.0;
+    float n = i * i + j * j;
+    float f = n * 0.0625;
+    
+    float isOn = step(0.1, intensity - f);
+    float brightness = isOn * (0.2 + y * 0.8) * (0.75 + x * 0.25);
+    
+    return step(0.0, p.x) * step(p.x, 1.0) * step(0.0, p.y) * step(p.y, 1.0) * brightness;
+}
+
+float onOff(float a, float b, float c)
+{
+  return step(c, sin(iTime + a * cos(iTime * b))) * uFlickerAmount;
+}
+
+float displace(vec2 look)
+{
+    float y = look.y - mod(iTime * 0.25, 1.0);
+    float window = 1.0 / (1.0 + 50.0 * y * y);
+    return sin(look.y * 20.0 + iTime) * 0.0125 * onOff(4.0, 2.0, 0.8) * (1.0 + cos(iTime * 60.0)) * window;
+}
+
+vec3 getColor(vec2 p){
+    
+    float bar = step(mod(p.y + time * 20.0, 1.0), 0.2) * 0.4 + 1.0;
+    bar *= uScanlineIntensity;
+    
+    float displacement = displace(p);
+    p.x += displacement;
+
+    if (uGlitchAmount != 1.0) {
+      float extra = displacement * (uGlitchAmount - 1.0);
+      p.x += extra;
+    }
+
+    float middle = digit(p);
+    
+    const float off = 0.002;
+    float sum = digit(p + vec2(-off, -off)) + digit(p + vec2(0.0, -off)) + digit(p + vec2(off, -off)) +
+                digit(p + vec2(-off, 0.0)) + digit(p + vec2(0.0, 0.0)) + digit(p + vec2(off, 0.0)) +
+                digit(p + vec2(-off, off)) + digit(p + vec2(0.0, off)) + digit(p + vec2(off, off));
+    
+    vec3 baseColor = vec3(0.9) * middle + sum * 0.1 * vec3(1.0) * bar;
+    return baseColor;
+}
+
+vec2 barrel(vec2 uv){
+  vec2 c = uv * 2.0 - 1.0;
+  float r2 = dot(c, c);
+  c *= 1.0 + uCurvature * r2;
+  return c * 0.5 + 0.5;
+}
+
+void main() {
+    time = iTime * 0.333333;
+    vec2 uv = vUv;
+
+    if(uCurvature != 0.0){
+      uv = barrel(uv);
+    }
+    
+    vec2 p = uv * uScale;
+    vec3 col = getColor(p);
+
+    if(uChromaticAberration != 0.0){
+      vec2 ca = vec2(uChromaticAberration) / iResolution.xy;
+      col.r = getColor(p + ca).r;
+      col.b = getColor(p - ca).b;
+    }
+
+    col *= uTint;
+    col *= uBrightness;
+
+    if(uDither > 0.0){
+      float rnd = hash21(gl_FragCoord.xy);
+      col += (rnd - 0.5) * (uDither * 0.003922);
+    }
+
+    gl_FragColor = vec4(col, 1.0);
+}
+`;
+
+function hexToRgb(hex: string): [number, number, number] {
+  let h = hex.replace('#', '').trim();
+  if (h.length === 3)
+    h = h
+      .split('')
+      .map(c => c + c)
+      .join('');
+  const num = parseInt(h, 16);
+  return [((num >> 16) & 255) / 255, ((num >> 8) & 255) / 255, (num & 255) / 255];
+}
+
+export default function FaultyTerminal({
+  scale = 1,
+  gridMul = [2, 1],
+  digitSize = 1.5,
+  timeScale = 0.3,
+  pause = false,
+  scanlineIntensity = 0.3,
+  glitchAmount = 1,
+  flickerAmount = 1,
+  noiseAmp = 1,
+  chromaticAberration = 0,
+  dither = 0,
+  curvature = 0.2,
+  tint = '#ffffff',
+  mouseReact = true,
+  mouseStrength = 0.2,
+  dpr = Math.min(typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1, 2),
+  pageLoadAnimation = true,
+  brightness = 1,
+  className,
+  style,
+  ...rest
+}: FaultyTerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const programRef = useRef<Program | null>(null);
+  const rendererRef = useRef<Renderer | null>(null);
+  const mouseRef = useRef({ x: 0.5, y: 0.5 });
+  const smoothMouseRef = useRef({ x: 0.5, y: 0.5 });
+  const frozenTimeRef = useRef(0);
+  const rafRef = useRef<number>(0);
+  const loadAnimationStartRef = useRef<number>(0);
+  const timeOffsetRef = useRef<number>(Math.random() * 100);
+
+  const tintVec = useMemo(() => hexToRgb(tint), [tint]);
+
+  const ditherValue = useMemo(() => (typeof dither === 'boolean' ? (dither ? 1 : 0) : dither), [dither]);
+
+  const handleMouseMove = useCallback((event: MouseEvent) => {
+    const ctn = containerRef.current;
+    if (!ctn) return;
+    const rect = ctn.getBoundingClientRect();
+    const x = (event.clientX - rect.left) / rect.width;
+    const y = 1 - (event.clientY - rect.top) / rect.height;
+    mouseRef.current = { x, y };
+  }, []);
+
+  useEffect(() => {
+    const ctn = containerRef.current;
+    if (!ctn) return;
+
+    const renderer = new Renderer({ dpr });
+    rendererRef.current = renderer;
+    const gl = renderer.gl;
+    gl.clearColor(0, 0, 0, 1);
+
+    const geometry = new Triangle(gl);
+
+    const program = new Program(gl, {
+      vertex: vertexShader,
+      fragment: fragmentShader,
+      uniforms: {
+        iTime: { value: 0 },
+        iResolution: {
+          value: new Color(gl.canvas.width, gl.canvas.height, gl.canvas.width / gl.canvas.height),
+        },
+        uScale: { value: scale },
+
+        uGridMul: { value: new Float32Array(gridMul) },
+        uDigitSize: { value: digitSize },
+        uScanlineIntensity: { value: scanlineIntensity },
+        uGlitchAmount: { value: glitchAmount },
+        uFlickerAmount: { value: flickerAmount },
+        uNoiseAmp: { value: noiseAmp },
+        uChromaticAberration: { value: chromaticAberration },
+        uDither: { value: ditherValue },
+        uCurvature: { value: curvature },
+        uTint: { value: new Color(tintVec[0], tintVec[1], tintVec[2]) },
+        uMouse: {
+          value: new Float32Array([smoothMouseRef.current.x, smoothMouseRef.current.y]),
+        },
+        uMouseStrength: { value: mouseStrength },
+        uUseMouse: { value: mouseReact ? 1 : 0 },
+        uPageLoadProgress: { value: pageLoadAnimation ? 0 : 1 },
+        uUsePageLoadAnimation: { value: pageLoadAnimation ? 1 : 0 },
+        uBrightness: { value: brightness },
+      },
+    });
+    programRef.current = program;
+
+    const mesh = new Mesh(gl, { geometry, program });
+
+    function resize() {
+      if (!ctn || !renderer) return;
+      renderer.setSize(ctn.offsetWidth, ctn.offsetHeight);
+      program.uniforms.iResolution.value = new Color(
+        gl.canvas.width,
+        gl.canvas.height,
+        gl.canvas.width / gl.canvas.height,
+      );
+    }
+
+    const resizeObserver = new ResizeObserver(() => resize());
+    resizeObserver.observe(ctn);
+    resize();
+
+    const update = (t: number) => {
+      rafRef.current = requestAnimationFrame(update);
+
+      if (pageLoadAnimation && loadAnimationStartRef.current === 0) {
+        loadAnimationStartRef.current = t;
+      }
+
+      if (!pause) {
+        const elapsed = (t * 0.001 + timeOffsetRef.current) * timeScale;
+        program.uniforms.iTime.value = elapsed;
+        frozenTimeRef.current = elapsed;
+      } else {
+        program.uniforms.iTime.value = frozenTimeRef.current;
+      }
+
+      if (pageLoadAnimation && loadAnimationStartRef.current > 0) {
+        const animationDuration = 2000;
+        const animationElapsed = t - loadAnimationStartRef.current;
+        const progress = Math.min(animationElapsed / animationDuration, 1);
+        program.uniforms.uPageLoadProgress.value = progress;
+      }
+
+      if (mouseReact) {
+        const dampingFactor = 0.08;
+        const smoothMouse = smoothMouseRef.current;
+        const mouse = mouseRef.current;
+        smoothMouse.x += (mouse.x - smoothMouse.x) * dampingFactor;
+        smoothMouse.y += (mouse.y - smoothMouse.y) * dampingFactor;
+
+        const mouseUniform = program.uniforms.uMouse.value as Float32Array;
+        mouseUniform[0] = smoothMouse.x;
+        mouseUniform[1] = smoothMouse.y;
+      }
+
+      renderer.render({ scene: mesh });
+    };
+    rafRef.current = requestAnimationFrame(update);
+    ctn.appendChild(gl.canvas);
+
+    if (mouseReact) window.addEventListener('mousemove', handleMouseMove);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      resizeObserver.disconnect();
+      if (mouseReact) window.removeEventListener('mousemove', handleMouseMove);
+      if (gl.canvas.parentElement === ctn) ctn.removeChild(gl.canvas);
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+      loadAnimationStartRef.current = 0;
+      timeOffsetRef.current = Math.random() * 100;
+    };
+  }, [
+    dpr,
+    pause,
+    timeScale,
+    scale,
+    gridMul,
+    digitSize,
+    scanlineIntensity,
+    glitchAmount,
+    flickerAmount,
+    noiseAmp,
+    chromaticAberration,
+    ditherValue,
+    curvature,
+    tintVec,
+    mouseReact,
+    mouseStrength,
+    pageLoadAnimation,
+    brightness,
+    handleMouseMove,
+  ]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`w-full h-full relative overflow-hidden pointer-events-none ${className ?? ''}`.trim()}
+      style={style}
+      {...rest}
+    />
+  );
+}

--- a/src/components/GridDistortion.tsx
+++ b/src/components/GridDistortion.tsx
@@ -1,0 +1,277 @@
+import React, { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+
+export interface GridDistortionProps extends React.HTMLAttributes<HTMLDivElement> {
+  grid?: number;
+  mouse?: number;
+  strength?: number;
+  relaxation?: number;
+  imageSrc: string;
+}
+
+const vertexShader = `
+uniform float time;
+varying vec2 vUv;
+varying vec3 vPosition;
+
+void main() {
+  vUv = uv;
+  vPosition = position;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+const fragmentShader = `
+uniform sampler2D uDataTexture;
+uniform sampler2D uTexture;
+uniform vec4 resolution;
+varying vec2 vUv;
+
+void main() {
+  vec2 uv = vUv;
+  vec4 offset = texture2D(uDataTexture, vUv);
+  gl_FragColor = texture2D(uTexture, uv - 0.02 * offset.rg);
+}
+`;
+
+export default function GridDistortion({
+  grid = 15,
+  mouse = 0.1,
+  strength = 0.15,
+  relaxation = 0.9,
+  imageSrc,
+  className = '',
+  style,
+  ...rest
+}: GridDistortionProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animationIdRef = useRef<number>();
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const scene = new THREE.Scene();
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: true,
+      powerPreference: 'high-performance'
+    });
+    const pixelRatio = typeof window !== 'undefined' ? Math.min(window.devicePixelRatio || 1, 2) : 1;
+    renderer.setPixelRatio(pixelRatio);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.setClearColor(0x000000, 0);
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
+    renderer.domElement.style.display = 'block';
+    container.replaceChildren(renderer.domElement);
+
+    const camera = new THREE.OrthographicCamera(-0.5, 0.5, 0.5, -0.5, -1000, 1000);
+    camera.position.z = 2;
+
+    const uniforms = {
+      time: { value: 0 },
+      resolution: { value: new THREE.Vector4() },
+      uTexture: { value: null as THREE.Texture | null },
+      uDataTexture: { value: null as THREE.DataTexture | null }
+    };
+
+    const loader = new THREE.TextureLoader();
+    let isDisposed = false;
+    loader.load(
+      imageSrc,
+      texture => {
+        if (isDisposed) return;
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.minFilter = THREE.LinearFilter;
+        texture.magFilter = THREE.LinearFilter;
+        texture.wrapS = THREE.ClampToEdgeWrapping;
+        texture.wrapT = THREE.ClampToEdgeWrapping;
+        uniforms.uTexture.value = texture;
+      },
+      undefined,
+      () => {
+        if (isDisposed) return;
+        console.warn('Unable to load GridDistortion texture:', imageSrc);
+      }
+    );
+
+    const size = Math.max(2, Math.floor(grid));
+    const data = new Float32Array(4 * size * size);
+    for (let i = 0; i < size * size; i++) {
+      data[i * 4] = (Math.random() - 0.5) * 0.5;
+      data[i * 4 + 1] = (Math.random() - 0.5) * 0.5;
+    }
+
+    const dataTexture = new THREE.DataTexture(data, size, size, THREE.RGBAFormat, THREE.FloatType);
+    dataTexture.needsUpdate = true;
+    uniforms.uDataTexture.value = dataTexture;
+
+    const material = new THREE.ShaderMaterial({
+      side: THREE.DoubleSide,
+      uniforms,
+      vertexShader,
+      fragmentShader,
+      transparent: true
+    });
+
+    const geometry = new THREE.PlaneGeometry(1, 1, size - 1, size - 1);
+    const plane = new THREE.Mesh(geometry, material);
+    scene.add(plane);
+
+    const handleResize = () => {
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const width = rect.width || 1;
+      const height = rect.height || 1;
+
+      renderer.setSize(width, height, false);
+
+      const containerAspect = width / height;
+      plane.scale.set(containerAspect, 1, 1);
+
+      const frustumHeight = 1;
+      const frustumWidth = frustumHeight * containerAspect;
+      camera.left = -frustumWidth / 2;
+      camera.right = frustumWidth / 2;
+      camera.top = frustumHeight / 2;
+      camera.bottom = -frustumHeight / 2;
+      camera.updateProjectionMatrix();
+
+      uniforms.resolution.value.set(width, height, pixelRatio, 1);
+    };
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const resizeObserver = new ResizeObserver(() => handleResize());
+      resizeObserver.observe(container);
+      resizeObserverRef.current = resizeObserver;
+    } else {
+      window.addEventListener('resize', handleResize);
+    }
+
+    const mouseState = {
+      x: 0,
+      y: 0,
+      prevX: 0,
+      prevY: 0,
+      vX: 0,
+      vY: 0,
+      hasMoved: false
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const rect = container.getBoundingClientRect();
+      const x = (event.clientX - rect.left) / rect.width;
+      const y = 1 - (event.clientY - rect.top) / rect.height;
+
+      const prevX = mouseState.hasMoved ? mouseState.prevX : x;
+      const prevY = mouseState.hasMoved ? mouseState.prevY : y;
+
+      mouseState.vX = x - prevX;
+      mouseState.vY = y - prevY;
+      mouseState.x = x;
+      mouseState.y = y;
+      mouseState.prevX = x;
+      mouseState.prevY = y;
+      mouseState.hasMoved = true;
+    };
+
+    const handleMouseLeave = () => {
+      dataTexture.needsUpdate = true;
+      mouseState.x = 0;
+      mouseState.y = 0;
+      mouseState.prevX = 0;
+      mouseState.prevY = 0;
+      mouseState.vX = 0;
+      mouseState.vY = 0;
+      mouseState.hasMoved = false;
+    };
+
+    container.addEventListener('mousemove', handleMouseMove);
+    container.addEventListener('mouseleave', handleMouseLeave);
+
+    handleResize();
+
+    const animate = () => {
+      animationIdRef.current = requestAnimationFrame(animate);
+
+      uniforms.time.value += 0.05;
+
+      const textureData = dataTexture.image.data as Float32Array;
+      for (let i = 0; i < size * size; i++) {
+        textureData[i * 4] *= relaxation;
+        textureData[i * 4 + 1] *= relaxation;
+      }
+
+      const gridMouseX = size * mouseState.x;
+      const gridMouseY = size * mouseState.y;
+      const maxDist = size * mouse;
+      const maxDistSq = maxDist * maxDist;
+
+      for (let i = 0; i < size; i++) {
+        for (let j = 0; j < size; j++) {
+          const distSq = (gridMouseX - i) * (gridMouseX - i) + (gridMouseY - j) * (gridMouseY - j);
+          if (distSq < maxDistSq) {
+            const index = 4 * (i + size * j);
+            const distance = Math.sqrt(Math.max(distSq, 0.0001));
+            const falloff = Math.min(maxDist / distance, 10);
+            textureData[index] += strength * 100 * mouseState.vX * falloff;
+            textureData[index + 1] -= strength * 100 * mouseState.vY * falloff;
+          }
+        }
+      }
+
+      dataTexture.needsUpdate = true;
+      renderer.render(scene, camera);
+    };
+
+    animate();
+
+    return () => {
+      isDisposed = true;
+
+      if (animationIdRef.current) {
+        cancelAnimationFrame(animationIdRef.current);
+      }
+
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      } else {
+        window.removeEventListener('resize', handleResize);
+      }
+
+      container.removeEventListener('mousemove', handleMouseMove);
+      container.removeEventListener('mouseleave', handleMouseLeave);
+
+      renderer.dispose();
+      if (container.contains(renderer.domElement)) {
+        container.removeChild(renderer.domElement);
+      }
+
+      geometry.dispose();
+      material.dispose();
+      dataTexture.dispose();
+      uniforms.uTexture.value?.dispose();
+    };
+  }, [grid, mouse, strength, relaxation, imageSrc]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative h-full w-full overflow-hidden pointer-events-auto ${className}`}
+      style={{
+        width: '100%',
+        height: '100%',
+        minWidth: 0,
+        minHeight: 0,
+        pointerEvents: 'auto',
+        ...style
+      }}
+      {...rest}
+    />
+  );
+}

--- a/src/components/Hero3D.tsx
+++ b/src/components/Hero3D.tsx
@@ -2,6 +2,8 @@ import { lazy, Suspense } from 'react';
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 
 const HeroCanvas = lazy(() => import('./HeroCanvas'));
+const FaultyTerminalBackground = lazy(() => import('./FaultyTerminal'));
+const GridDistortionBackground = lazy(() => import('./GridDistortion'));
 
 const StaticIllustration = () => (
   <div className="pointer-events-none absolute inset-0 -z-10 flex items-center justify-center">
@@ -43,11 +45,57 @@ const StaticIllustration = () => (
 export default function Hero3D() {
   const prefersReducedMotion = usePrefersReducedMotion();
 
+  const heroBackground = import.meta.env.VITE_HERO_BACKGROUND?.toLowerCase();
   const isHero3DEnabled =
-    import.meta.env.VITE_ENABLE_HERO_3D?.toLowerCase() === 'true';
+    import.meta.env.VITE_ENABLE_HERO_3D?.toLowerCase() === 'true' || heroBackground === '3d';
+  const shouldUseGridDistortion =
+    heroBackground === 'grid-distortion' || (!heroBackground && !isHero3DEnabled);
+  const shouldUseFaultyTerminal = heroBackground === 'faulty-terminal';
 
-  if (prefersReducedMotion || !isHero3DEnabled) {
+  if (prefersReducedMotion || heroBackground === 'static') {
     return <StaticIllustration />;
+  }
+
+  if (shouldUseGridDistortion) {
+    return (
+      <Suspense fallback={<StaticIllustration />}>
+        <div className="pointer-events-none fixed inset-0 -z-20">
+          <GridDistortionBackground
+            grid={18}
+            mouse={0.12}
+            strength={0.18}
+            relaxation={0.88}
+            imageSrc="/images/artleo-hero.svg"
+          />
+        </div>
+      </Suspense>
+    );
+  }
+
+  if (shouldUseFaultyTerminal) {
+    return (
+      <Suspense fallback={<StaticIllustration />}>
+        <div className="pointer-events-none fixed inset-0 -z-20">
+          <FaultyTerminalBackground
+            scale={1.5}
+            gridMul={[2, 1]}
+            digitSize={1.2}
+            timeScale={1}
+            scanlineIntensity={1}
+            glitchAmount={1}
+            flickerAmount={0.9}
+            noiseAmp={1}
+            chromaticAberration={0.0015}
+            dither={0.6}
+            curvature={0.08}
+            tint="#a5f3fc"
+            mouseStrength={0.25}
+            pageLoadAnimation
+            brightness={1.05}
+          />
+        </div>
+      </Suspense>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- add a GridDistortion background component adapted from the ReactBits effect
- default the hero background to the new grid distortion effect while keeping previous options available
- wire the effect to the existing art hero texture and maintain pointer interaction
- pin the grid and faulty terminal backgrounds so they cover the full home page viewport

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4f68297688322a1017f02f62e15e2